### PR TITLE
Add Local Links Manager assets to Capistrano config file

### DIFF
--- a/local-links-manager/config/deploy.rb
+++ b/local-links-manager/config/deploy.rb
@@ -1,8 +1,16 @@
 set :application, "local-links-manager"
 set :capfile_dir, File.expand_path('../', File.dirname(__FILE__))
 set :server_class, "backend"
+set :run_migrations_by_default, true
 
 load 'defaults'
 load 'ruby'
+load 'deploy/assets'
+load 'govuk_admin_template'
+
+set :copy_exclude, [
+ '.git/*',
+ 'public/**/*'
+]
 
 after "deploy:notify", "deploy:notify:errbit"


### PR DESCRIPTION
Also set migrations to run by default.

Also added govuk_admin_template and excluded unnecessary directories.
