### PR TITLE
Add deploy scripts for service-manual-frontend

### DIFF
--- a/service-manual-frontend/Capfile
+++ b/service-manual-frontend/Capfile
@@ -1,0 +1,6 @@
+load 'deploy'
+
+$:.unshift(File.expand_path('../../lib', __FILE__))
+load_paths << File.expand_path('../../recipes', __FILE__)
+
+load    'config/deploy'

--- a/service-manual-frontend/config/deploy.rb
+++ b/service-manual-frontend/config/deploy.rb
@@ -1,0 +1,15 @@
+set :application, "service-manual-frontend"
+set :capfile_dir, File.expand_path('../', File.dirname(__FILE__))
+set :server_class, [
+  "draft_frontend",
+  "frontend",
+]
+
+load 'defaults'
+load 'ruby'
+load 'deploy/assets'
+
+set :assets_prefix, 'service-manual-frontend'
+set :rails_env, 'production'
+
+after "deploy:notify", "deploy:notify:errbit"


### PR DESCRIPTION
Similar to government-frontend except more 12factor-y. Errbit key and
Secret key set via env vars in hieradata.

Was https://github.gds/gds/alphagov-deployment/pull/1175
