### PR TITLE
Set Jenkins Gemfile location

### DIFF
--- a/jenkins.sh
+++ b/jenkins.sh
@@ -15,7 +15,7 @@ if [ ! -d "$TARGET_APPLICATION" ]; then
   cd "alphagov-deployment/$TARGET_APPLICATION"
   if [ -e "deploy.sh" ]; then
     echo "---> Found deploy.sh, running 'sh -e deploy.sh'" >&2
-    exec sh -e deploy.sh
+    exec env BUNDLE_GEMFILE="$WORKSPACE/Gemfile" sh -e deploy.sh
   else
     echo "---> No deploy.sh found, running 'bundle exec cap \"${DEPLOY_TASK}\"'" >&2
     exec env BUNDLE_GEMFILE="$WORKSPACE/Gemfile" bundle exec cap "$DEPLOY_TASK"


### PR DESCRIPTION
- Release, Trade Tariff and EFG use a deploy.sh script. Their deploys will fail currently as Jenkins is looking for Bundler in the wrong place. This sets the Bundler version to the one in the workspace Gemfile.

cc @h-lame 
