### PR TITLE
Minor changes to Jenkins script

### DIFF
--- a/jenkins.sh
+++ b/jenkins.sh
@@ -27,8 +27,7 @@ fi
 cd "$TARGET_APPLICATION"
 
 if [ -d "../alphagov-deployment/${TARGET_APPLICATION}" ]; then
-  mkdir secrets
-  cp -r ../alphagov-deployment/$TARGET_APPLICATION/* secrets
+  cp -r ../alphagov-deployment/$TARGET_APPLICATION secrets
 fi
 
 if [ -e "deploy.sh" ]; then


### PR DESCRIPTION
- Fetch only the most recent commit on master for alphagov-deployment, to speed up deploys - they've been taking several minutes longer than usual since we switched to using this script in Integration
- Simplify the command to copy the app's directory from alphagov-deployment
