### PR TITLE
Handle rummager and email-alert-api requests asynchronously in specialist-publisher-rebuild

### DIFF
--- a/specialist-publisher-rebuild-standalone/config/deploy.rb
+++ b/specialist-publisher-rebuild-standalone/config/deploy.rb
@@ -8,4 +8,5 @@ load 'ruby'
 load 'deploy/assets'
 load 'govuk_admin_template'
 
+after "deploy:restart", "deploy:restart_procfile_worker"
 after "deploy:notify", "deploy:notify:errbit"

--- a/specialist-publisher-rebuild/config/deploy.rb
+++ b/specialist-publisher-rebuild/config/deploy.rb
@@ -7,4 +7,5 @@ load 'ruby'
 load 'deploy/assets'
 load 'govuk_admin_template'
 
+after "deploy:restart", "deploy:restart_procfile_worker"
 after "deploy:notify", "deploy:notify:errbit"


### PR DESCRIPTION
https://trello.com/c/ITpVoqdD/141-offload-search-and-email-alert-requests-to-a-message-queue-when-publishing-medium

This is one of four pull requests to make the handling of rummagerand email-alert-api requests asynchronous in specialist publisher rebuild. We are making this change so that the application is more resilient to network and wider-system problems. Here are all the pull requests:
- https://github.com/alphagov/specialist-publisher-rebuild/pull/792
- https://github.com/alphagov/govuk-puppet/pull/4478
- https://github.com/alphagov/govuk-app-deployment/pull/16 (this one)
- https://github.gds/gds/development/pull/323
