### PR TITLE
Temporarily remove publising-api worker restart.

### DIFF
--- a/publishing-api/config/deploy.rb
+++ b/publishing-api/config/deploy.rb
@@ -11,7 +11,6 @@ set :config_files_to_upload, {
   "secrets/to_upload/rabbitmq.yml.erb" => "config/rabbitmq.yml",
 }
 
-after "deploy:restart", "deploy:restart_procfile_worker"
 after "deploy:notify", "deploy:notify:errbit"
 after "deploy:finalize_update", "deploy:symlink_schemas"
 


### PR DESCRIPTION
This is so that we can change the Redis namespace for Sidekiq without
losing the jobs already on the queue. When the existing jobs have all
been processed, we will restart the worker manually and restore this
line.
