### PR TITLE
Add Whenever to Local Links Manager

### DIFF
--- a/local-links-manager/config/deploy.rb
+++ b/local-links-manager/config/deploy.rb
@@ -8,6 +8,9 @@ load 'ruby'
 load 'deploy/assets'
 load 'govuk_admin_template'
 
+set :whenever_command, "bundle exec whenever"
+require "whenever/capistrano" # This hooks a task to run before deploy:finalize_update
+
 set :copy_exclude, [
  '.git/*',
  'public/**/*'


### PR DESCRIPTION
Local Links Manager now uses the Whenever gem to schedule jobs instead
of using Jenkins

[Related PR](https://github.com/alphagov/local-links-manager/pull/29)

[Trello card](https://trello.com/c/KBT9RC9q/406-check-the-status-code-of-links)