### PR TITLE
Add dfid-transition

### DIFF
--- a/dfid-transition/Capfile
+++ b/dfid-transition/Capfile
@@ -1,0 +1,6 @@
+load 'deploy'
+
+$:.unshift(File.expand_path('../../lib', __FILE__))
+load_paths << File.expand_path('../../recipes', __FILE__)
+
+load 'config/deploy'

--- a/dfid-transition/config/deploy.rb
+++ b/dfid-transition/config/deploy.rb
@@ -1,0 +1,8 @@
+set :application, "dfid-transition"
+set :capfile_dir, File.expand_path('../', File.dirname(__FILE__))
+set :server_class, "backend"
+
+load 'defaults'
+load 'ruby'
+
+after "deploy:restart", "deploy:restart_procfile_worker"


### PR DESCRIPTION
Although dfid-transition has a short shelf life, we need a sidekiq
job or two to assist with the transition of 20K PDFs/30K research
outputs. This app is just that.