### PR TITLE
SPIKE: Exclude regression test artefacts in Smart Answers deployment

### DIFF
--- a/smartanswers/config/deploy.rb
+++ b/smartanswers/config/deploy.rb
@@ -13,6 +13,8 @@ set :db_config_file, false
 set :rails_env, 'production'
 set :source_db_config_file, false
 
+set :rsync_options, "#{rsync_options} --exclude 'test/artefacts'"
+
 namespace :deploy do
   task :cold do
     puts "There's no cold task for this project, just deploy normally"


### PR DESCRIPTION
This is a speculative and un-tested change which aims to speed up the deployment of the Smart Answers app.

It appears as if the Smart Answers deployment recipe uses the [default deployment strategy][1], i.e. `rsync_with_remote_cache`. Reading the [documentation for this strategy][2], it sounds as if deployment happens in three steps:

1. Local cache is updated from the git repo
2. Local cache is synced to the remote cache (in shared directory) via rsync
3. Remote cache is synced to the new release directory via rsync

The intention of this PR is to avoid syncing the `test/artefacts` directory in step 2 and therefore also in step 3. This directory contains regression test artefacts which are not needed in production. There are a large number of files in a deep directory structure and we think that this might be making steps 2 and 3 very slow.

Before merging this PR, I'd suggest the following:

* Verify that steps 2 & 3 are indeed the bottleneck for the deployment
* If so, then test that the change in this commit works as intended

In newer versions of Capistrano, the SCM checkout recipe for Git uses the [`git archive` command][3] which means it would be possible to add the [`export-ignore` Git attribute][4] to the `test/artefacts` directory. This would mean that this directory would never be exported to the local cache in step 1. This might be a better solution in the longer run.

[1]: https://github.com/alphagov/govuk-app-deployment/blob/af49ab487577c636014e8f6274c55f4e9e4d325b/recipes/defaults.rb#L5
[2]: https://github.com/alphagov/capistrano_rsync_with_remote_cache/blob/ce74ee4854673fa9ec436f0f6560c845993b3ff0/README.rdoc#under-the-hood
[3]: https://git-scm.com/docs/git-archive
[4]: https://git-scm.com/docs/gitattributes