### PR TITLE
Add deploy scripts for rummager

### DIFF
--- a/rummager/Capfile
+++ b/rummager/Capfile
@@ -1,0 +1,6 @@
+load 'deploy'
+
+$:.unshift(File.expand_path('../../lib', __FILE__))
+load_paths << File.expand_path('../../recipes', __FILE__)
+
+load 'config/deploy'

--- a/rummager/config/deploy.rb
+++ b/rummager/config/deploy.rb
@@ -1,0 +1,63 @@
+set :application, "rummager"
+set :capfile_dir, File.expand_path('../', File.dirname(__FILE__))
+set :server_class, "search"
+
+load 'defaults'
+load 'ruby'
+
+set :whenever_command, "bundle exec whenever"
+require "whenever/capistrano"
+
+set :source_db_config_file, false
+set :db_config_file, false
+
+set :config_files_to_upload, {
+  "secrets/to_upload/redis.yml" => "config/redis.yml",
+}
+
+set :copy_exclude, [
+  '.git/*',
+  'public',
+]
+
+namespace :deploy do
+  task :symlink_sitemaps do
+    # Preserve the directory containing sitemap files between releases
+    run <<-EOT
+      rm -rf #{latest_release}/public/sitemaps &&
+      mkdir -p #{shared_path}/system/sitemaps &&
+      ln -s #{shared_path}/system/sitemaps #{latest_release}/public/sitemaps
+    EOT
+
+    # Preserve the generated sitemap.xml symlink from the previous release if present.
+    #
+    # This de-references the symlink to ensure that it's pointing directly into the shared dir.
+    # Otherwise there's a risk of the previous release being cleaned up and this becoming a
+    # dangling symlink
+    run <<-EOT
+      test -L #{previous_release}/public/sitemap.xml || exit 0;
+      ln -s `readlink -nf #{previous_release}/public/sitemap.xml` #{latest_release}/public/sitemap.xml
+    EOT
+  end
+
+  task :migrate, :roles => :db, :only => { :primary => true } do
+    run "cd #{current_release}; #{rake} RACK_ENV=#{rack_env} RUMMAGER_INDEX=all rummager:migrate_index rummager:clean"
+  end
+
+  desc "Teardown SSH connections to force Capistrano to reopen them in case they have timed out"
+  task :teardown_connections do
+    teardown_connections_to(find_servers)
+  end
+
+  desc "Restart rummager's publishing-api listener"
+  task :restart_publishing_api_listener do
+    run "sudo initctl start rummager-publishing-queue-listener-procfile-worker || sudo initctl restart rummager-publishing-queue-listener-procfile-worker"
+  end
+end
+
+after "deploy:finalize_update", "deploy:symlink_sitemaps"
+after "deploy:symlink", "deploy:publishing_api:publish_special_routes"
+after "deploy:restart", "deploy:restart_procfile_worker"
+after "deploy:restart", "deploy:restart_publishing_api_listener"
+after "deploy:notify", "deploy:notify:errbit"
+after "deploy:migrate", "deploy:teardown_connections"


### PR DESCRIPTION
Taken from alphagov-deployment. Only change was changing `to_upload/redis.yml` to `secrets/to_upload/redis.yml`.

https://trello.com/c/dKfYzDNx

Removed from alphagov-deployment in https://github.gds/gds/alphagov-deployment/pull/1211