### PR TITLE
Add worker restart to content tagger

### DIFF
--- a/content-tagger/config/deploy.rb
+++ b/content-tagger/config/deploy.rb
@@ -21,3 +21,4 @@ set :copy_exclude, [
 ]
 
 after "deploy:notify", "deploy:notify:errbit"
+after "deploy:restart", "deploy:restart_procfile_worker"


### PR DESCRIPTION
As per https://github.com/alphagov/govuk_sidekiq/blob/9c52d10857a62fc333342a56a74ac4a526f007e3/README.md#5-configure-deployment-scripts