### PR TITLE
Add recipe for Sidekiq Monitoring

### DIFF
--- a/sidekiq-monitoring/Capfile
+++ b/sidekiq-monitoring/Capfile
@@ -1,0 +1,6 @@
+load 'deploy'
+
+$:.unshift(File.expand_path('../../lib', __FILE__))
+load_paths << File.expand_path('../../recipes', __FILE__)
+
+load 'config/deploy'

--- a/sidekiq-monitoring/config/deploy.rb
+++ b/sidekiq-monitoring/config/deploy.rb
@@ -1,0 +1,9 @@
+set :application, 'sidekiq-monitoring'
+set :capfile_dir, File.expand_path('../', File.dirname(__FILE__))
+set :server_class, 'backend'
+
+load 'defaults'
+load 'ruby'
+
+after 'deploy:restart', 'deploy:restart_procfile_worker'
+after 'deploy:notify', 'deploy:notify:errbit'


### PR DESCRIPTION
This is intended to replace the existing deployment recipe.

The existing recipe needs updating to remove the syncing of the Redis YAML config files introduced by moving to configuration provided by the environment in alphagov/sidekiq-monitoring#25 and alphagov/govuk-puppet#4731. 

I've used that as an opportunity to move to the new world.