### PR TITLE
Add data directory to Local Links Manager releases

### DIFF
--- a/local-links-manager/config/deploy.rb
+++ b/local-links-manager/config/deploy.rb
@@ -16,4 +16,27 @@ set :copy_exclude, [
  'public/**/*'
 ]
 
+namespace :deploy do
+  desc <<-DESC
+    Create the data directory for CSV exports.
+  DESC
+  task :setup_data_directory do
+    run <<-EOT
+mkdir -p #{shared_path}/data
+    EOT
+  end
+
+  desc <<-DESC
+    Symlink the shared data directory into the new release.
+  DESC
+  task :symlink_data_directory do
+    run <<-EOT
+rm -rf #{latest_release}/public/data &&
+ln -s #{shared_path}/data #{latest_release}/public/data
+    EOT
+  end
+end
+
+after "deploy:setup", "deploy:setup_data_directory"
+after "deploy:finalize_update", "deploy:symlink_data_directory"
 after "deploy:notify", "deploy:notify:errbit"


### PR DESCRIPTION
- Create `data` directory on deploy in `shared` directory and then symlink into `public/data` inside the current release.
- This is to hold the exported CSV containing local authority services links which will be used by data.gov.uk.

[Trello card](https://trello.com/c/dFFQRlsp/448-generate-local-links-csv-3)

Mobbed with @brenetic @issyl0 