### PR TITLE
Add find-local-council Rummager index

### DIFF
--- a/frontend/config/deploy.rb
+++ b/frontend/config/deploy.rb
@@ -59,5 +59,7 @@ after "deploy:upload_initializers", "deploy:upload_unicorn_config"
 
 after "deploy:symlink", "deploy:panopticon:register"
 after "deploy:symlink", "deploy:publishing_api:publish_special_routes"
+after "deploy:symlink", "deploy:rummager:index"
+
 before "deploy:assets:precompile", "deploy:mustache_precompile"
 after "deploy:notify", "deploy:notify:errbit"


### PR DESCRIPTION
Rummager needs to be notified to index upon Frontend deployment

Note: Only merge after https://github.com/alphagov/frontend/pull/986 gets merged!

[Trello card](https://trello.com/c/RXWWvAZk/461-use-publishing-api-to-manage-routes-and-tagging-for-find-local-council)

In conjunction with:
https://github.com/alphagov/publishing-api/pull/461
https://github.com/alphagov/frontend/pull/986 (last commit)
https://github.com/alphagov/panopticon/pull/390