### PR TITLE
Run publishing_api:publish task on deploy

### DIFF
--- a/policy-publisher/config/deploy.rb
+++ b/policy-publisher/config/deploy.rb
@@ -14,3 +14,4 @@ set :config_files_to_upload, {
 }
 
 after "deploy:notify", "deploy:notify:errbit"
+after "deploy:symlink", "deploy:publishing_api:publish"


### PR DESCRIPTION
More context: https://github.com/alphagov/policy-publisher/pull/151. That PR should be merged first to not upset integration deploys.