### PR TITLE
Index documents in Rummager directly on deploy

### DIFF
--- a/businesssupportfinder/config/deploy.rb
+++ b/businesssupportfinder/config/deploy.rb
@@ -13,5 +13,6 @@ set :source_db_config_file, false
 set :db_config_file, false
 
 after "deploy:symlink", "deploy:panopticon:register"
+after "deploy:symlink", "deploy:rummager:index_all"
 after "deploy:symlink", "deploy:publishing_api:publish"
 after "deploy:notify", "deploy:notify:errbit"

--- a/calculators/config/deploy.rb
+++ b/calculators/config/deploy.rb
@@ -14,5 +14,6 @@ set :source_db_config_file, false
 
 after "deploy:upload_initializers", "deploy:symlink_mailer_config"
 after "deploy:symlink", "deploy:panopticon:register"
+after "deploy:symlink", "deploy:rummager:index_all"
 after "deploy:symlink", "deploy:publishing_api:publish"
 after "deploy:notify", "deploy:notify:errbit"

--- a/calendars/config/deploy.rb
+++ b/calendars/config/deploy.rb
@@ -19,5 +19,6 @@ end
 
 after "deploy:upload_initializers", "deploy:symlink_mailer_config"
 after "deploy:symlink", "deploy:panopticon:register"
+after "deploy:symlink", "deploy:rummager:index_all"
 after "deploy:symlink", "deploy:publishing_api:publish"
 after "deploy:notify", "deploy:notify:errbit"

--- a/licencefinder/config/deploy.rb
+++ b/licencefinder/config/deploy.rb
@@ -21,4 +21,5 @@ set :copy_exclude, [
 
 after "deploy:upload_initializers", "deploy:symlink_mailer_config"
 after "deploy:symlink", "deploy:panopticon:register"
+after "deploy:symlink", "deploy:rummager:index_all"
 after "deploy:symlink", "deploy:publishing_api:publish"

--- a/smartanswers/config/deploy.rb
+++ b/smartanswers/config/deploy.rb
@@ -20,5 +20,6 @@ namespace :deploy do
 end
 
 after "deploy:symlink", "deploy:panopticon:register"
+after "deploy:symlink", "deploy:rummager:index_all"
 after "deploy:symlink", "deploy:publishing_api:publish"
 after "deploy:notify", "deploy:notify:errbit"


### PR DESCRIPTION
Previously, panopticon would send artifacts to Rummager. That flow is now being
deprecated in favour of a simpler approach which is to send documents directly
to rummager.

This means additional rake tasks need to run after deploy in order to make sure
these applications index their documents in Rummager.

Trello ticket: https://trello.com/c/gsHnT5WF/161-epic-send-things-to-rummager-directly-instead-of-via-panopticon