### PR TITLE
Correct bearer token commentary

### DIFF
--- a/recipes/defaults.rb
+++ b/recipes/defaults.rb
@@ -93,8 +93,8 @@ namespace :deploy do
             "deployment[environment]" => organisation
           }
           request.set_form_data(form_data)
-          request["Accept"] = "application/json" # So that gds-sso will treat us as an API client
-          request["Authorization"] = "Bearer #{bearer_token}"
+          request["Accept"] = "application/json"
+          request["Authorization"] = "Bearer #{bearer_token}" # So that gds-sso will treat us as an API client
           response = conn.request(request)
           puts "Deployment notification response:"
           puts "#{response.code} #{response.body}"


### PR DESCRIPTION
API calls are determined by the presence of a bearer token since
alphagov/gds-sso#107.

cc @alexmuller 