### PR TITLE
Announce deploys on Slack

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,3 +10,4 @@ gem "railsless-deploy", :require => false
 gem "rake"
 gem "whenever", "0.7.3"
 gem "govuk-lint", "~> 1.2"
+gem "http", "~> 2.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -10,6 +10,7 @@ GEM
   remote: http://rubygems.org/
   specs:
     activesupport (3.0.8)
+    addressable (2.4.0)
     ast (2.3.0)
     capistrano (2.9.0)
       highline
@@ -18,10 +19,21 @@ GEM
       net-ssh (>= 2.0.14)
       net-ssh-gateway (>= 1.1.0)
     chronic (0.6.7)
+    domain_name (0.5.20160826)
+      unf (>= 0.0.5, < 1.0.0)
     govuk-lint (1.2.0)
       rubocop (~> 0.39.0)
       scss_lint
     highline (1.6.11)
+    http (2.0.3)
+      addressable (~> 2.3)
+      http-cookie (~> 1.0)
+      http-form_data (~> 1.0.1)
+      http_parser.rb (~> 0.6.0)
+    http-cookie (1.0.2)
+      domain_name (~> 0.5)
+    http-form_data (1.0.1)
+    http_parser.rb (0.6.0)
     net-scp (1.0.4)
       net-ssh (>= 1.99.1)
     net-sftp (2.0.5)
@@ -46,6 +58,9 @@ GEM
     scss_lint (0.49.0)
       rake (>= 0.9, < 12)
       sass (~> 3.4.20)
+    unf (0.1.4)
+      unf_ext
+    unf_ext (0.0.7.2)
     unicode-display_width (1.1.0)
     whenever (0.7.3)
       activesupport (>= 2.3.4)
@@ -58,6 +73,7 @@ DEPENDENCIES
   capistrano (= 2.9.0)
   capistrano_rsync_with_remote_cache!
   govuk-lint (~> 1.2)
+  http (~> 2.0)
   railsless-deploy
   rake
   whenever (= 0.7.3)

--- a/recipes/defaults.rb
+++ b/recipes/defaults.rb
@@ -67,6 +67,7 @@ namespace :deploy do
   namespace :notify do
     task :default do
       release_app
+      slack_message
       graphite_event
     end
 
@@ -102,6 +103,23 @@ namespace :deploy do
           puts "Release notification failed: #{e.message}"
           raise manual_resolution_message
         end
+      end
+    end
+
+    desc "Announce the deploy on Slack"
+    task :slack_message do
+      begin
+        require 'http'
+
+        message_payload = {
+          username: "Badger",
+          icon_emoji: ":badger:",
+          text: "[#{application}](https://github.com/alphagov/#{repo_name}) was just deployed to **#{ENV['ORGANISATION']}**",
+        }
+
+        HTTP.post(ENV["BADGER_SLACK_WEBHOOK_URL"], body: JSON.dump(message_payload))
+      rescue => e
+        puts "Release notification to slack failed: #{e.message}"
       end
     end
 


### PR DESCRIPTION
This commit adds an extra step in the deploy process to announce deploys to slack.

Notification will be posted to #govuk-deploys for now. [It uses this Slack integration](https://govuk.slack.com/services/82708562020).

Needs https://github.gds/gds/deployment/pull/1093 to work.