### PR TITLE
Deploy specialist-publisher-rebuild as specialist-publisher

### DIFF
--- a/specialist-publisher/Capfile
+++ b/specialist-publisher/Capfile
@@ -1,0 +1,6 @@
+load 'deploy'
+
+$:.unshift(File.expand_path('../../lib', __FILE__))
+load_paths << File.expand_path('../../recipes', __FILE__)
+
+load 'config/deploy'

--- a/specialist-publisher/config/deploy.rb
+++ b/specialist-publisher/config/deploy.rb
@@ -8,5 +8,15 @@ load 'ruby'
 load 'deploy/assets'
 load 'govuk_admin_template'
 
+
+# FIXME This is a temporary measure to prevent initializers from the original
+# Specialist Publisher application being deployed into the Specialist Publisher
+# Rebuild application. This can be safely removed once the initializers have
+# been removed from the old deployment repo.
+["deploy:upload_config", "deploy:upload_initializers"].each do |callback_source|
+  callback = callbacks[:after].find { |c| c.source == callback_source }
+  callbacks[:after].delete(callback)
+end
+
 after "deploy:restart", "deploy:restart_procfile_worker"
 after "deploy:notify", "deploy:notify:errbit"

--- a/specialist-publisher/config/deploy.rb
+++ b/specialist-publisher/config/deploy.rb
@@ -1,0 +1,12 @@
+set :application, "specialist-publisher"
+set :capfile_dir, File.expand_path('../', File.dirname(__FILE__))
+set :server_class, "backend"
+set :repo_name, "specialist-publisher-rebuild"
+
+load 'defaults'
+load 'ruby'
+load 'deploy/assets'
+load 'govuk_admin_template'
+
+after "deploy:restart", "deploy:restart_procfile_worker"
+after "deploy:notify", "deploy:notify:errbit"


### PR DESCRIPTION
add files to redeploy specialist publisher rebuild in the place of old specialist publisher.

Old specialist publisher (now manuals publisher) was not deployed using this repo previously
This pr should add files to deploy a new copy of specialist publisher rebuild in the place
of specialist publisher v1