### PR TITLE
Don't try to upload rabbitmq.yml.

### DIFF
--- a/publishing-api/config/deploy.rb
+++ b/publishing-api/config/deploy.rb
@@ -7,10 +7,6 @@ set :run_migrations_by_default, true
 load 'defaults'
 load 'ruby'
 
-set :config_files_to_upload, {
-  "secrets/to_upload/rabbitmq.yml.erb" => "config/rabbitmq.yml",
-}
-
 after "deploy:restart", "deploy:restart_procfile_worker"
 after "deploy:notify", "deploy:notify:errbit"
 after "deploy:finalize_update", "deploy:symlink_schemas"


### PR DESCRIPTION
This file has been removed from alphagov-deployment but Capistrano is still trying to upload it.