### PR TITLE
Run migrations by default when deploying Manuals Publisher

### DIFF
--- a/manuals-publisher/config/deploy.rb
+++ b/manuals-publisher/config/deploy.rb
@@ -1,6 +1,7 @@
 set :application, "manuals-publisher"
 set :capfile_dir, File.expand_path('../', File.dirname(__FILE__))
 set :server_class, "backend"
+set :run_migrations_by_default, true
 
 load 'defaults'
 load 'ruby'


### PR DESCRIPTION
Manuals Publisher ([the app formerly known as Specialist Publisher](https://github.gds/gds/alphagov-deployment/blob/1c4b7063/specialist-publisher/config/deploy.rb#L19)) has it's own data store so we should run migrations when deploying it.
