### PR TITLE
Post deploy messages for prod & staging to #2ndline

### DIFF
--- a/recipes/defaults.rb
+++ b/recipes/defaults.rb
@@ -144,11 +144,16 @@ namespace :deploy do
       begin
         require 'http'
 
+        environment_name = ENV['ORGANISATION']
+
+        next unless environment_name.in?(%w(production staging))
+
         message_payload = {
           username: "Badger",
           icon_emoji: ":badger:",
-          text: "<https://github.com/alphagov/#{repo_name}|#{application}> was just deployed to *#{ENV['ORGANISATION']}*",
+          text: "<https://github.com/alphagov/#{repo_name}|#{application}> was just deployed to *#{environment_name}*",
           mrkdwn: true,
+          channel: '#2ndline',
         }
 
         HTTP.post(ENV["BADGER_SLACK_WEBHOOK_URL"], body: JSON.dump(message_payload))

--- a/recipes/defaults.rb
+++ b/recipes/defaults.rb
@@ -147,7 +147,7 @@ namespace :deploy do
         message_payload = {
           username: "Badger",
           icon_emoji: ":badger:",
-          text: "<https://github.com/alphagov/#{repo_name}|#{application}> was just deployed to *#{ENV['ORGANISATION']}* (SHA: <https://github.com/alphagov/#{repo_name}/commits/#{current_revision}|#{current_revision[0..7]}>)",
+          text: "<https://github.com/alphagov/#{repo_name}|#{application}> was just deployed to *#{ENV['ORGANISATION']}*",
           mrkdwn: true,
         }
 


### PR DESCRIPTION
The deploy announcements for integration seem not very useful in the #govuk-deploy channel. The actual human-triggered deploys however do seem useful, but are drowned out by the integration messages.

This silences any integration messages and posts the useful messages to #2ndline, so everyone can see them.