### PR TITLE
Fix slack deploy notification

### DIFF
--- a/recipes/defaults.rb
+++ b/recipes/defaults.rb
@@ -146,7 +146,7 @@ namespace :deploy do
 
         environment_name = ENV['ORGANISATION']
 
-        next unless environment_name.in?(%w(production staging))
+        next unless %w(production staging).include?(environment_name)
 
         message_payload = {
           username: "Badger",


### PR DESCRIPTION
`Array#in?` is an active-support method, and we don't have that loaded here (because it's not Rails).