### PR TITLE
Don't run migrations by default for efg-training

### DIFF
--- a/efg-training/config/deploy.rb
+++ b/efg-training/config/deploy.rb
@@ -9,7 +9,8 @@ require "whenever/capistrano"
 set :source_db_config_file, 'secrets/to_upload/database.yml'
 set :db_config_file, 'config/database.yml'
 
-set :run_migrations_by_default, true
+# FIXME: Set to true when the database is set up
+set :run_migrations_by_default, false
 
 load 'defaults'
 load 'ruby'


### PR DESCRIPTION
We've never deployed efg-training before - the list of the migrations in the EFG app is long and doesn't complete successfully against an empty database, which makes Capistrano rollback the deploy and remove the application code.

I want to get a copy of the app deployed so that I can run a rake task to load the database from `schema.rb`, at which point all future deploys should be set to run migrations.