### PR TITLE
Add configuration for govuk-content-schemas

### DIFF
--- a/govuk-content-schemas/Capfile
+++ b/govuk-content-schemas/Capfile
@@ -1,0 +1,14 @@
+# This application has no service, as other applications that use it
+# (e.g. the Publishing API) just load the schemas that it provides
+# directly from the file system.
+#
+# The deployment process only needs to make the files in the
+# repository available on the machines where applications depending on
+# the govuk-content-schemas are running.
+
+load 'deploy'
+
+$:.unshift(File.expand_path('../../lib', __FILE__))
+load_paths << File.expand_path('../../recipes', __FILE__)
+
+load 'config/deploy'

--- a/govuk-content-schemas/config/deploy.rb
+++ b/govuk-content-schemas/config/deploy.rb
@@ -1,0 +1,5 @@
+set :application, "govuk-content-schemas"
+set :capfile_dir, File.expand_path('../', File.dirname(__FILE__))
+set :server_class, %w(backend)
+
+load 'defaults'


### PR DESCRIPTION
This is needed on backend machines such that the Publishing API can
validate the payloads it receives using the schemas.

Previously the govuk-content-schemas deployment was managed separately,
and while it is not a service with a running process, its current use
via the Publishing API is equivalent to a dependant
application (e.g. the content-store), its just that the interface is
currently over the filesystem, and not over HTTP.

I'm interested in feedback about this, as I'm unsure if this is the right approach. Also, this is completely untested, as I'm not sure how to test this.