### PR TITLE
Change the finder publishing rake task name for contacts

### DIFF
--- a/contacts/config/deploy.rb
+++ b/contacts/config/deploy.rb
@@ -30,5 +30,5 @@ set :copy_exclude, [
   "public/templates"
 ]
 
-after "deploy:symlink", "deploy:publishing_api:publish_special_routes"
+after "deploy:symlink", "deploy:publishing_api:publish"
 after "deploy:notify", "deploy:notify:errbit"


### PR DESCRIPTION
This commit changes the name of the rake task that publishes the finders from the contacts app during deployment. The new rake task publishes a finder used by finder-frontend.

Trello: https://trello.com/c/wD10DEXt/260-migrate-the-hmrc-contacts-page-to-a-finder

To be merged just before deployment of https://github.com/alphagov/contacts-admin/pull/249.