### PR TITLE
Disable finder publishing temporarily

### DIFF
--- a/contacts/config/deploy.rb
+++ b/contacts/config/deploy.rb
@@ -30,5 +30,5 @@ set :copy_exclude, [
   "public/templates"
 ]
 
-after "deploy:symlink", "deploy:publishing_api:publish"
+# after "deploy:symlink", "deploy:publishing_api:publish"
 after "deploy:notify", "deploy:notify:errbit"


### PR DESCRIPTION
Until we've re-indexed the contacts, so that they show up when faceting with a topic.