### PR TITLE
Remove procfile worker task for panopticon

### DIFF
--- a/panopticon/config/deploy.rb
+++ b/panopticon/config/deploy.rb
@@ -22,4 +22,3 @@ set :copy_exclude, [
 after "deploy:migrate", "deploy:create_mongoid_indexes"
 after "deploy:symlink", "deploy:seed_db"
 after "deploy:notify", "deploy:notify:errbit"
-after "deploy:restart", "deploy:restart_procfile_worker"


### PR DESCRIPTION
The process in the Procfile is no longer necessary and has been removed (https://github.com/alphagov/panopticon/pull/409).