### PR TITLE
Add metadata-api deploy config and Capfile

### DIFF
--- a/metadata-api/Capfile
+++ b/metadata-api/Capfile
@@ -1,0 +1,5 @@
+$:.unshift(File.expand_path('../../lib', __FILE__))
+load_paths << File.expand_path('../../recipes', __FILE__)
+
+require 'railsless-deploy'
+load    'config/deploy'

--- a/metadata-api/config/deploy.rb
+++ b/metadata-api/config/deploy.rb
@@ -1,0 +1,39 @@
+require 'fetch_build'
+
+set :application, "metadata-api"
+set :capfile_dir, File.expand_path('../', File.dirname(__FILE__))
+set :server_class, "api"
+
+# Use the build number from the release tag if given
+# Otherwise, this will fall back to using the lastSuccessfulBuild below.
+if ENV["TAG"] =~ /\Arelease_(\d+)\z/
+  set :artefact_number, $1
+end
+
+load 'defaults'
+
+namespace :deploy do
+  # This overrides the default update_code task
+  desc "Copies the CI build artefact to the remote servers."
+  task :update_code, :except => { :no_release => true } do
+    on_rollback { run "rm -rf #{release_path}; true" }
+    run "mkdir -p #{release_path}"
+
+    ci_base_url = "https://deploy_jenkins:#{ENV['CI_DEPLOY_JENKINS_API_KEY']}@ci.dev.publishing.service.gov.uk/job/govuk_#{application}"
+
+    artefact_to_deploy = fetch(:artefact_number, fetch_last_build_number(ci_base_url))
+    put "#{artefact_to_deploy}\n", "#{release_path}/build_number"
+
+    artefact_url = "#{ci_base_url}/#{artefact_to_deploy}/artifact/#{application}"
+    logger.info "Fetching #{artefact_url} from CI server"
+    file = fetch_to_tempfile(artefact_url)
+    top.upload file, "#{release_path}/#{application}", :mode => "0755"
+  end
+
+  task :restart, :roles => :app, :except => { :no_release => true } do
+    # The deploy user always has permission to run initctl commands.
+    run "sudo initctl start #{application} 2>/dev/null || sudo initctl reload #{application}"
+  end
+end
+
+after "deploy:update_code"


### PR DESCRIPTION
Part of https://trello.com/c/BrKRdn4f/495-rebuild-gov-uk-app-deployment-pipeline

Depends on https://github.com/alphagov/govuk-puppet/pull/5098 and https://github.com/alphagov/metadata-api/pull/30