### PR TITLE
Remove govuk-content-schemas symlinking

### DIFF
--- a/content-store/config/deploy.rb
+++ b/content-store/config/deploy.rb
@@ -17,10 +17,4 @@ set :whenever_command, "govuk_setenv content-store bundle exec whenever"
 
 after "deploy:symlink", "deploy:create_mongoid_indexes"
 after "deploy:notify", "deploy:notify:errbit"
-after "deploy:finalize_update", "deploy:symlink_schemas"
-
-namespace :deploy do
-  task :symlink_schemas do
-    run "ln -sfn /data/apps/content-store/shared/govuk-content-schemas #{latest_release}/govuk-content-schemas"
-  end
-end
+after "deploy:finalize_update"

--- a/publishing-api/config/deploy.rb
+++ b/publishing-api/config/deploy.rb
@@ -9,10 +9,4 @@ load 'ruby'
 
 after "deploy:restart", "deploy:restart_procfile_worker"
 after "deploy:notify", "deploy:notify:errbit"
-after "deploy:finalize_update", "deploy:symlink_schemas"
-
-namespace :deploy do
-  task :symlink_schemas do
-    run "ln -sfn /data/apps/publishing-api/shared/govuk-content-schemas #{latest_release}/govuk-content-schemas"
-  end
-end
+after "deploy:finalize_update"


### PR DESCRIPTION
Previously the Publishing API would access the govuk-content-schemas
through a symlink, it now accesses them directly from the current app
directory.

As for the content store, it no longer uses the govuk-content-schemas at all.