### PR TITLE
Add deploy notifications for govuk-content-schemas

### DIFF
--- a/govuk-content-schemas/config/deploy.rb
+++ b/govuk-content-schemas/config/deploy.rb
@@ -3,3 +3,5 @@ set :capfile_dir, File.expand_path('../', File.dirname(__FILE__))
 set :server_class, %w(backend)
 
 load 'defaults'
+
+after "deploy:notify", "deploy:notify:github"


### PR DESCRIPTION
One of the things that this will to is generate deployed-to-* branches,
which can then be used when running tests for applications.