### PR TITLE
Add Support app deploy config

### DIFF
--- a/support/Capfile
+++ b/support/Capfile
@@ -1,0 +1,6 @@
+load 'deploy'
+
+$:.unshift(File.expand_path('../../lib', __FILE__))
+load_paths << File.expand_path('../../recipes', __FILE__)
+
+load 'config/deploy'

--- a/support/config/deploy.rb
+++ b/support/config/deploy.rb
@@ -1,0 +1,12 @@
+set :application, "support"
+set :capfile_dir, File.expand_path('../', File.dirname(__FILE__))
+set :server_class, "backend"
+
+load 'defaults'
+load 'ruby'
+load 'deploy/assets'
+
+load 'govuk_admin_template'
+
+after "deploy:restart", "deploy:restart_procfile_worker"
+after "deploy:notify", "deploy:notify:errbit"


### PR DESCRIPTION
Part of https://trello.com/c/BrKRdn4f/495-rebuild-gov-uk-app-deployment-pipeline

Moving to the new deployment pipeline

Depends on https://github.com/alphagov/govuk-puppet/pull/5121 and https://github.com/alphagov/support/pull/296