### PR TITLE
Remove finalize_update

### DIFF
--- a/content-store/config/deploy.rb
+++ b/content-store/config/deploy.rb
@@ -17,4 +17,3 @@ set :whenever_command, "govuk_setenv content-store bundle exec whenever"
 
 after "deploy:symlink", "deploy:create_mongoid_indexes"
 after "deploy:notify", "deploy:notify:errbit"
-after "deploy:finalize_update"

--- a/publishing-api/config/deploy.rb
+++ b/publishing-api/config/deploy.rb
@@ -9,4 +9,3 @@ load 'ruby'
 
 after "deploy:restart", "deploy:restart_procfile_worker"
 after "deploy:notify", "deploy:notify:errbit"
-after "deploy:finalize_update"


### PR DESCRIPTION
`after 'deploy/finalize_update'` needs an argument which has been
removed in https://github.com/alphagov/govuk-app-deployment/commit/c0d06da747fb1c048aa42333b84cc1457a2d235f
so these need to be removed as it is currently breaking the deploy.
see https://deploy.integration.publishing.service.gov.uk/job/Deploy_App/8306/console