### PR TITLE
Add Travel Advice Publisher deployment config

### DIFF
--- a/travel-advice-publisher/Capfile
+++ b/travel-advice-publisher/Capfile
@@ -1,0 +1,6 @@
+load 'deploy'
+
+$:.unshift(File.expand_path('../../lib', __FILE__))
+load_paths << File.expand_path('../../recipes', __FILE__)
+
+load 'config/deploy'

--- a/travel-advice-publisher/config/deploy.rb
+++ b/travel-advice-publisher/config/deploy.rb
@@ -1,0 +1,18 @@
+set :application, "travel-advice-publisher"
+set :capfile_dir, File.expand_path('../', File.dirname(__FILE__))
+set :server_class, "backend"
+
+set :run_migrations_by_default, true
+
+load 'defaults'
+load 'ruby'
+load 'deploy/assets'
+
+load 'govuk_admin_template'
+
+set :rails_env, 'production'
+
+after "deploy:symlink", "deploy:panopticon:register"
+after "deploy:symlink", "deploy:publishing_api:publish"
+after "deploy:restart", "deploy:restart_procfile_worker"
+after "deploy:notify", "deploy:notify:errbit"


### PR DESCRIPTION
Part of https://trello.com/c/BrKRdn4f/495-rebuild-gov-uk-app-deployment-pipeline

Adds Travel Advice Publisher to this project.

Depends on https://github.com/alphagov/travel-advice-publisher/pull/164 and https://github.com/alphagov/govuk-puppet/pull/5152