### PR TITLE
Publish finders when specialist-publisher is deployed

### DIFF
--- a/specialist-publisher/config/deploy.rb
+++ b/specialist-publisher/config/deploy.rb
@@ -7,5 +7,13 @@ load 'ruby'
 load 'deploy/assets'
 load 'govuk_admin_template'
 
+namespace :deploy do
+  desc "Publish all Finders to the Publishing API"
+  task :publish_finders do
+    run "cd #{current_release}; #{rake} publishing_api:publish_finders"
+  end
+end
+
+after "deploy:setup", "deploy:publish_finders"
 after "deploy:restart", "deploy:restart_procfile_worker"
 after "deploy:notify", "deploy:notify:errbit"


### PR DESCRIPTION
Trello: https://trello.com/c/pR2Trbfj/383-add-task-to-run-during-specialist-publisher-deploy

- The rake task to publish all finders to publishing-api is now run when
specialist-publisher is deployed.

Paired with @Davidslv 