### PR TITLE
Revert "Publish finders when specialist-publisher is deployed"

### DIFF
--- a/specialist-publisher/config/deploy.rb
+++ b/specialist-publisher/config/deploy.rb
@@ -7,13 +7,5 @@ load 'ruby'
 load 'deploy/assets'
 load 'govuk_admin_template'
 
-namespace :deploy do
-  desc "Publish all Finders to the Publishing API"
-  task :publish_finders do
-    run "cd #{current_release}; #{rake} publishing_api:publish_finders"
-  end
-end
-
-after "deploy:setup", "deploy:publish_finders"
 after "deploy:restart", "deploy:restart_procfile_worker"
 after "deploy:notify", "deploy:notify:errbit"


### PR DESCRIPTION
Reverts alphagov/govuk-app-deployment#87.

The publishing-api is not reliable enough at the moment to republish everything on deploy.