### PR TITLE
Inform Errbit when Service Manual Publisher deploys

### DIFF
--- a/service-manual-publisher/config/deploy.rb
+++ b/service-manual-publisher/config/deploy.rb
@@ -10,3 +10,4 @@ load 'deploy/assets'
 load 'govuk_admin_template'
 
 after "deploy:upload_initializers", "deploy:symlink_mailer_config"
+after "deploy:notify", "deploy:notify:errbit"


### PR DESCRIPTION
Service Manual Publisher doesn't inform Errbit of new deployments.  If it does then Errbit will, by default, show only errors since the last deploy which makes it easier to see which problems are still present. [Service manual frontend does this already][1].

[1]: https://github.com/alphagov/govuk-app-deployment/blob/master/service-manual-frontend/config/deploy.rb#L12