### PR TITLE
Remove Frontend Panopticon route registration

### DIFF
--- a/frontend/config/deploy.rb
+++ b/frontend/config/deploy.rb
@@ -52,7 +52,6 @@ end
 after "deploy:upload_initializers", "deploy:upload_private_initializers"
 after "deploy:upload_initializers", "deploy:upload_unicorn_config"
 
-after "deploy:symlink", "deploy:panopticon:register"
 after "deploy:symlink", "deploy:publishing_api:publish_special_routes"
 after "deploy:symlink", "deploy:rummager:index"
 


### PR DESCRIPTION
Frontend registers special routes on deploy. We no longer wish Panopticon to register routes on deployment.

Related PR - https://github.com/alphagov/frontend/pull/1091

[Trello card](https://trello.com/c/hWf4N5mK/587-register-frontend-routes-only-through-publishing-api-3)