### PR TITLE
Remove panopticon register tasks

### DIFF
--- a/businesssupportfinder/config/deploy.rb
+++ b/businesssupportfinder/config/deploy.rb
@@ -12,7 +12,6 @@ set :rails_env, 'production'
 set :source_db_config_file, false
 set :db_config_file, false
 
-after "deploy:symlink", "deploy:panopticon:register"
 after "deploy:symlink", "deploy:rummager:index"
 after "deploy:symlink", "deploy:publishing_api:publish"
 after "deploy:notify", "deploy:notify:errbit"

--- a/calculators/config/deploy.rb
+++ b/calculators/config/deploy.rb
@@ -13,7 +13,6 @@ set :rails_env, 'production'
 set :source_db_config_file, false
 
 after "deploy:upload_initializers", "deploy:symlink_mailer_config"
-after "deploy:symlink", "deploy:panopticon:register"
 after "deploy:symlink", "deploy:rummager:index"
 after "deploy:symlink", "deploy:publishing_api:publish"
 after "deploy:notify", "deploy:notify:errbit"

--- a/calendars/config/deploy.rb
+++ b/calendars/config/deploy.rb
@@ -18,7 +18,6 @@ namespace :deploy do
 end
 
 after "deploy:upload_initializers", "deploy:symlink_mailer_config"
-after "deploy:symlink", "deploy:panopticon:register"
 after "deploy:symlink", "deploy:rummager:index"
 after "deploy:symlink", "deploy:publishing_api:publish"
 after "deploy:notify", "deploy:notify:errbit"

--- a/licencefinder/config/deploy.rb
+++ b/licencefinder/config/deploy.rb
@@ -20,6 +20,5 @@ set :copy_exclude, [
 ]
 
 after "deploy:upload_initializers", "deploy:symlink_mailer_config"
-after "deploy:symlink", "deploy:panopticon:register"
 after "deploy:symlink", "deploy:rummager:index"
 after "deploy:symlink", "deploy:publishing_api:publish"

--- a/recipes/defaults.rb
+++ b/recipes/defaults.rb
@@ -190,14 +190,6 @@ namespace :deploy do
     end
   end
 
-  namespace :panopticon do
-    task :register, :only => { :primary => true, :draft => false } do
-      rails_env = fetch(:rails_env, "production")
-      rake = fetch(:rake)
-      run "cd #{current_release}; #{rake} RAILS_ENV=#{rails_env} panopticon:register", :once => true
-    end
-  end
-
   namespace :publishing_api do
     task :publish, :only => { :primary => true, :draft => false } do
       rails_env = fetch(:rails_env, "production")

--- a/smartanswers/config/deploy.rb
+++ b/smartanswers/config/deploy.rb
@@ -19,7 +19,6 @@ namespace :deploy do
   end
 end
 
-after "deploy:symlink", "deploy:panopticon:register"
 after "deploy:symlink", "deploy:rummager:index"
 after "deploy:symlink", "deploy:publishing_api:publish"
 after "deploy:notify", "deploy:notify:errbit"

--- a/travel-advice-publisher/config/deploy.rb
+++ b/travel-advice-publisher/config/deploy.rb
@@ -12,7 +12,6 @@ load 'govuk_admin_template'
 
 set :rails_env, 'production'
 
-after "deploy:symlink", "deploy:panopticon:register"
 after "deploy:symlink", "deploy:publishing_api:publish"
 after "deploy:restart", "deploy:restart_procfile_worker"
 after "deploy:notify", "deploy:notify:errbit"


### PR DESCRIPTION
Panopticon no longer needs to have artefacts.

Merge after https://github.com/alphagov/content-tagger/pull/261 is deployed.

Trello: https://trello.com/c/7u8M6zrg