### PR TITLE
Remove running of `whenever` command

### DIFF
--- a/content-performance-manager/config/deploy.rb
+++ b/content-performance-manager/config/deploy.rb
@@ -6,6 +6,3 @@ set :run_migrations_by_default, true
 
 load 'defaults'
 load 'ruby'
-
-require "whenever/capistrano"
-set :whenever_command, "bundle exec whenever"


### PR DESCRIPTION
content-performance-manager does not have any cron jobs so there is no need to
run a command that schedules cron jobs.