### PR TITLE
Add config to deploy assets

### DIFF
--- a/content-performance-manager/config/deploy.rb
+++ b/content-performance-manager/config/deploy.rb
@@ -6,3 +6,4 @@ set :run_migrations_by_default, true
 
 load 'defaults'
 load 'ruby'
+load 'deploy/assets'


### PR DESCRIPTION
The assets (css etc) are not being copied when content-performance-manager is
deployed. I think this is because Capistrano has not been told to deploy them.