### PR TITLE
Set asset prefix for content-performance-manager

### DIFF
--- a/content-performance-manager/config/deploy.rb
+++ b/content-performance-manager/config/deploy.rb
@@ -7,3 +7,6 @@ set :run_migrations_by_default, true
 load 'defaults'
 load 'ruby'
 load 'deploy/assets'
+
+set :assets_prefix, 'content-performance-manager'
+set :rails_env, 'production'


### PR DESCRIPTION
The assets (css etc) for content-performance-manager are still not deploying.
Hopefully this will be fixed by setting the asset prefix and setting the
environment.