### PR TITLE
Change search-admin deploy config

### DIFF
--- a/search-admin/config/deploy.rb
+++ b/search-admin/config/deploy.rb
@@ -7,12 +7,7 @@ set :run_migrations_by_default, true
 load 'defaults'
 load 'ruby'
 load 'deploy/assets'
-
-set :source_db_config_file, 'secrets/to_upload/database.yml'
-
-set :config_files_to_upload, {
-  'secrets/to_upload/secrets.yml' => 'config/secrets.yml'
-}
+load 'govuk_admin_template'
 
 set :copy_exclude, [
   '.git/*',


### PR DESCRIPTION
search-admin is moving to the new deployment pipeline.

This commit removes the deployment steps where files containing secrets are copied from GHE, overwriting placeholders in the public app repository. These files are included in the app repo as of https://github.com/alphagov/search-admin/pull/71.

It also loads and runs the `govuk_admin_template` task, which sets the environment indicators in the app header.

Depends on https://github.com/alphagov/govuk-puppet/pull/5430 and https://github.com/alphagov/search-admin/pull/71

Trello: https://trello.com/c/tjUur3ec/462-move-search-admin-to-new-deployment-pipeline