### PR TITLE
Fetch artefacts and build numbers from new CI

### DIFF
--- a/govuk_crawler_worker/config/deploy.rb
+++ b/govuk_crawler_worker/config/deploy.rb
@@ -19,7 +19,7 @@ namespace :deploy do
     on_rollback { run "rm -rf #{release_path}; true" }
     run "mkdir -p #{release_path}"
 
-    ci_base_url = "https://deploy_jenkins:#{ENV['CI_DEPLOY_JENKINS_API_KEY']}@ci.dev.publishing.service.gov.uk/job/#{application}"
+    ci_base_url = "https://ci_alphagov:#{ENV['CI_DEPLOY_JENKINS_API_KEY']}@ci.integration.publishing.service.gov.uk/job/#{application}/job/master"
 
     artefact_to_deploy = fetch(:artefact_number, fetch_last_build_number(ci_base_url))
     put "#{artefact_to_deploy}\n", "#{release_path}/build_number"

--- a/metadata-api/config/deploy.rb
+++ b/metadata-api/config/deploy.rb
@@ -19,7 +19,7 @@ namespace :deploy do
     on_rollback { run "rm -rf #{release_path}; true" }
     run "mkdir -p #{release_path}"
 
-    ci_base_url = "https://deploy_jenkins:#{ENV['CI_DEPLOY_JENKINS_API_KEY']}@ci.dev.publishing.service.gov.uk/job/govuk_#{application}"
+    ci_base_url = "https://ci_alphagov:#{ENV['CI_DEPLOY_JENKINS_API_KEY']}@ci.integration.publishing.service.gov.uk/job/#{application}/job/master"
 
     artefact_to_deploy = fetch(:artefact_number, fetch_last_build_number(ci_base_url))
     put "#{artefact_to_deploy}\n", "#{release_path}/build_number"

--- a/router/config/deploy.rb
+++ b/router/config/deploy.rb
@@ -19,7 +19,7 @@ namespace :deploy do
     on_rollback { run "rm -rf #{release_path}; true" }
     run "mkdir -p #{release_path}"
 
-    ci_base_url = "https://deploy_jenkins:#{ENV['CI_DEPLOY_JENKINS_API_KEY']}@ci.dev.publishing.service.gov.uk/job/govuk_router"
+    ci_base_url = "https://ci_alphagov:#{ENV['CI_DEPLOY_JENKINS_API_KEY']}@ci.integration.publishing.service.gov.uk/job/router/job/master"
 
     artefact_to_deploy = fetch(:artefact_number, fetch_last_build_number(ci_base_url))
     put "#{artefact_to_deploy}\n", "#{release_path}/build_number"


### PR DESCRIPTION
https://trello.com/c/kLrX1PqG/580-move-metadata-api-to-new-ci-infrastructure-1-blocked-by-jenkins

Updates deployment scripts to fetch build numbers and artefacts from ci.integration.publishing.service.gov.uk