### PR TITLE
Load the admin template in Content Performance Manager

### DIFF
--- a/content-performance-manager/config/deploy.rb
+++ b/content-performance-manager/config/deploy.rb
@@ -8,4 +8,6 @@ load 'defaults'
 load 'ruby'
 load 'deploy/assets'
 
+load 'govuk_admin_template'
+
 set :rails_env, 'production'


### PR DESCRIPTION
## Description
The Content Performance Manager currently uses the `govuk_admin_template` gem but was not using its corresponding recipe on deploy. This change ensures admin environment variables are set e.g. the header shows `development` and `production` respectively.