### PR TITLE
Remove uploading of "secrets" for content store

### DIFF
--- a/content-store/config/deploy.rb
+++ b/content-store/config/deploy.rb
@@ -7,11 +7,6 @@ set :run_migrations_by_default, true
 load 'defaults'
 load 'ruby'
 
-set :config_files_to_upload, {
-  "secrets/to_upload/rabbitmq.yml.erb" => "config/rabbitmq.yml",
-  "secrets/to_upload/unicorn.rb" => "config/unicorn.rb",
-}
-
 require "whenever/capistrano"
 set :whenever_command, "govuk_setenv content-store bundle exec whenever"
 


### PR DESCRIPTION
The rabbitmq config is no longer needed, and the unicorn config isn’t
secret.

Depends on https://github.com/alphagov/content-store/pull/279 being deployed