### PR TITLE
Restart Sidekiq worker after deployment

### DIFF
--- a/content-performance-manager/config/deploy.rb
+++ b/content-performance-manager/config/deploy.rb
@@ -11,3 +11,4 @@ load 'deploy/assets'
 load 'govuk_admin_template'
 
 set :rails_env, 'production'
+after "deploy:restart", "deploy:restart_procfile_worker"


### PR DESCRIPTION
Makes sure the Sidekiq worker in the Content Performance Manager
restarts after deploying by adding a hook. Otherwise, the worker will 
keep running old code.