### PR TITLE
Remove private-frontend

### DIFF
--- a/frontend/config/deploy.rb
+++ b/frontend/config/deploy.rb
@@ -1,6 +1,6 @@
 set :application, "frontend"
 set :capfile_dir, File.expand_path('../', File.dirname(__FILE__))
-set :server_class, %w(draft_frontend frontend backend)
+set :server_class, %w(draft_frontend frontend)
 
 set :source_db_config_file, false
 set :db_config_file, false


### PR DESCRIPTION
Private-frontend is being turned off and is currently deployed to the backend
machines, so we remove backend from the server classes so that it is no longer
deployed there.

[Trello](https://trello.com/c/JYT9roQm/709-turn-off-private-frontend)