### PR TITLE
Stop Frontend initializer upload for backend machines

### DIFF
--- a/frontend/config/deploy.rb
+++ b/frontend/config/deploy.rb
@@ -27,14 +27,6 @@ namespace :deploy do
       end
     end
   end
-  task :upload_private_initializers, :only => { :server_class => "backend" } do
-    config_folder = File.expand_path("secrets/to_upload/private_initializers/#{rails_env}", Dir.pwd)
-    if File.exist?(config_folder)
-      Dir.glob(File.join(config_folder, "*.rb")).each do |initializer|
-        top.upload(initializer, File.join(release_path, "config/initializers/#{File.basename(initializer)}"))
-      end
-    end
-  end
   task :upload_unicorn_config, :only => { :server_class => "frontend" } do
     config_file = File.expand_path("secrets/to_upload/unicorn.rb", Dir.pwd)
     if File.exist?(config_file)
@@ -49,7 +41,6 @@ end
 if ENV['ORGANISATION'] == 'integration'
   after "deploy:upload_initializers", "deploy:upload_integration_initializers"
 end
-after "deploy:upload_initializers", "deploy:upload_private_initializers"
 after "deploy:upload_initializers", "deploy:upload_unicorn_config"
 
 after "deploy:symlink", "deploy:publishing_api:publish_special_routes"


### PR DESCRIPTION
Since we are no longer deploying Frontend to backend machines we no longer need to upload any initializers which were specifically for backend purposes.

https://trello.com/c/JYT9roQm/709-turn-off-private-frontend

[Related PR](https://github.gds/gds/alphagov-deployment/pull/1311)

cc @emmabeynon 