### PR TITLE
Test current badger (Slack) deployment announcements

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,0 +1,2 @@
+--color
+--require spec_helper

--- a/Gemfile
+++ b/Gemfile
@@ -11,3 +11,5 @@ gem "rake"
 gem "whenever", "0.7.3"
 gem "govuk-lint", "~> 1.2"
 gem "http", "~> 2.0"
+
+gem "rspec"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -19,6 +19,7 @@ GEM
       net-ssh (>= 2.0.14)
       net-ssh-gateway (>= 1.1.0)
     chronic (0.6.7)
+    diff-lcs (1.2.5)
     domain_name (0.5.20160826)
       unf (>= 0.0.5, < 1.0.0)
     govuk-lint (1.2.0)
@@ -47,6 +48,19 @@ GEM
     railsless-deploy (1.0.2)
     rainbow (2.1.0)
     rake (0.9.2)
+    rspec (3.5.0)
+      rspec-core (~> 3.5.0)
+      rspec-expectations (~> 3.5.0)
+      rspec-mocks (~> 3.5.0)
+    rspec-core (3.5.2)
+      rspec-support (~> 3.5.0)
+    rspec-expectations (3.5.0)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.5.0)
+    rspec-mocks (3.5.0)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.5.0)
+    rspec-support (3.5.0)
     rubocop (0.39.0)
       parser (>= 2.3.0.7, < 3.0)
       powerpack (~> 0.1)
@@ -76,4 +90,8 @@ DEPENDENCIES
   http (~> 2.0)
   railsless-deploy
   rake
+  rspec
   whenever (= 0.7.3)
+
+BUNDLED WITH
+   1.14.5

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -33,6 +33,10 @@ node {
     stage("Lint Ruby") {
       govuk.rubyLinter("*/*")
     }
+
+    stage("Tests") {
+      govuk.runTests()
+    }
   } catch (e) {
     currentBuild.result = "FAILED"
     step([$class: 'Mailer',

--- a/Rakefile
+++ b/Rakefile
@@ -1,0 +1,5 @@
+require 'rspec/core/rake_task'
+
+RSpec::Core::RakeTask.new(:spec)
+
+task :default => :spec

--- a/lib/slack_announcer.rb
+++ b/lib/slack_announcer.rb
@@ -1,0 +1,24 @@
+require 'http'
+
+class SlackAnnouncer
+  def initialize(environment_name, slack_url)
+    @environment_name = environment_name
+    @slack_url = slack_url
+  end
+
+  def announce(repo_name, application)
+    return unless %w(production staging).include?(@environment_name)
+
+    message_payload = {
+      username: "Badger",
+      icon_emoji: ":badger:",
+      text: "<https://github.com/alphagov/#{repo_name}|#{application}> was just deployed to *#{@environment_name}*",
+      mrkdwn: true,
+      channel: '#2ndline',
+    }
+
+    HTTP.post(@slack_url, body: JSON.dump(message_payload))
+  rescue => e
+    puts "Release notification to slack failed: #{e.message}"
+  end
+end

--- a/recipes/defaults.rb
+++ b/recipes/defaults.rb
@@ -141,25 +141,8 @@ namespace :deploy do
 
     desc "Announce the deploy on Slack"
     task :slack_message do
-      begin
-        require 'http'
-
-        environment_name = ENV['ORGANISATION']
-
-        next unless %w(production staging).include?(environment_name)
-
-        message_payload = {
-          username: "Badger",
-          icon_emoji: ":badger:",
-          text: "<https://github.com/alphagov/#{repo_name}|#{application}> was just deployed to *#{environment_name}*",
-          mrkdwn: true,
-          channel: '#2ndline',
-        }
-
-        HTTP.post(ENV["BADGER_SLACK_WEBHOOK_URL"], body: JSON.dump(message_payload))
-      rescue => e
-        puts "Release notification to slack failed: #{e.message}"
-      end
+      annoucer = SlackAnnouncer.new(ENV['ORGANISATION'], ENV['BADGER_SLACK_WEBHOOK_URL'])
+      annoucer.announce(repo_name, application)
     end
 
     desc "Record the deployment as a Graphite event"

--- a/spec/slack_announcer_spec.rb
+++ b/spec/slack_announcer_spec.rb
@@ -1,0 +1,35 @@
+require "spec_helper"
+require "slack_announcer"
+
+RSpec.describe SlackAnnouncer do
+  %w(staging production).each do |environment_name|
+    it "annouces a #{environment_name} deploy to slack" do
+      expect(HTTP).to receive(:post) do |url, params|
+        expect(url).to eq('http://slack.url')
+        expect(JSON.parse(params[:body])).to include(
+          "username" => "Badger",
+          "text" => "<https://github.com/alphagov/alphagov/whitehall|Whitehall> was just deployed to *#{environment_name}*",
+          "channel" => "#2ndline",
+        )
+      end
+
+      announcer = described_class.new(environment_name, "http://slack.url")
+      announcer.announce("alphagov/whitehall", "Whitehall")
+    end
+  end
+
+  it "does not announce deploys to other environments" do
+    expect(HTTP).not_to receive(:post)
+
+    announcer = described_class.new("integration", "http://slack.url")
+    announcer.announce("alphagov/whitehall", "Whitehall")
+  end
+
+  it "logs and swallows announcement errors so that the deployment does not fail" do
+    expect(HTTP).to receive(:post).and_raise(StandardError)
+
+    announcer = described_class.new("production", "http://slack.url")
+    expect(announcer).to receive(:puts).with(/StandardError/)
+    expect { announcer.announce("alphagov/whitehall", "Whitehall") }.not_to raise_error
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,0 +1,21 @@
+RSpec.configure do |config|
+  config.expect_with :rspec do |expectations|
+    expectations.include_chain_clauses_in_custom_matcher_descriptions = true
+  end
+
+  config.mock_with :rspec do |mocks|
+    mocks.verify_partial_doubles = true
+  end
+
+  config.shared_context_metadata_behavior = :apply_to_host_groups
+  config.filter_run_when_matching :focus
+  config.disable_monkey_patching!
+  config.warnings = true
+
+  if config.files_to_run.one?
+    config.default_formatter = 'doc'
+  end
+
+  config.order = :random
+  Kernel.srand config.seed
+end


### PR DESCRIPTION
- Add RSpec support
- Add tests for badger announcements to the 2ndline Slack channel
- Add tests to the Jenkins file so they are run in CI

This is in preparation for adding more features (monitoring dashboard links) to the badger announcements.

Paired with @dwhenry on this PR.

Trello: https://trello.com/c/IcBRUByV/18-add-link-to-dashboards-in-release-app-and-or-badger