### PR TITLE
Add missing `require` to fix post-deployment Slack announcements

### DIFF
--- a/recipes/defaults.rb
+++ b/recipes/defaults.rb
@@ -1,5 +1,7 @@
 load "set_servers"
 
+require "slack_announcer"
+
 set :branch,        ENV["TAG"] ? ENV["TAG"] : "master"
 set :deploy_to,     "/data/apps/#{application}"
 set :deploy_via,    :rsync_with_remote_cache


### PR DESCRIPTION
😳 

https://trello.com/c/IcBRUByV/18-add-link-to-dashboards-in-release-app-and-or-badger