### PR TITLE
Add dashboard link to badger notification for whitehall deployment

### DIFF
--- a/lib/slack_announcer.rb
+++ b/lib/slack_announcer.rb
@@ -6,7 +6,7 @@ class SlackAnnouncer
     @slack_url = slack_url
   end
 
-  def announce(repo_name, application)
+  def announce(repo_name, application, slack_channel = "#2ndline")
     return unless %w(production staging).include?(@environment_name)
 
     message_payload = {
@@ -14,7 +14,7 @@ class SlackAnnouncer
       icon_emoji: ":badger:",
       text: "<https://github.com/alphagov/#{repo_name}|#{application}> was just deployed to *#{@environment_name}*",
       mrkdwn: true,
-      channel: '#2ndline',
+      channel: slack_channel,
     }
 
     HTTP.post(@slack_url, body: JSON.dump(message_payload))

--- a/lib/slack_announcer.rb
+++ b/lib/slack_announcer.rb
@@ -9,10 +9,15 @@ class SlackAnnouncer
   def announce(repo_name, application, slack_channel = "#2ndline")
     return unless %w(production staging).include?(@environment_name)
 
+    text = "<https://github.com/alphagov/#{repo_name}|#{application}> was just deployed to *#{@environment_name}*"
+    if repo_name == "alphagov/whitehall"
+      text += "\n:chart_with_upwards_trend: Why not check out the <https://#{dashboard_host_name}/dashboard/db/prototype-dashboard-whitehall|#{application} deployment dashboard>?"
+    end
+
     message_payload = {
       username: "Badger",
       icon_emoji: ":badger:",
-      text: "<https://github.com/alphagov/#{repo_name}|#{application}> was just deployed to *#{@environment_name}*",
+      text: text,
       mrkdwn: true,
       channel: slack_channel,
     }
@@ -20,5 +25,12 @@ class SlackAnnouncer
     HTTP.post(@slack_url, body: JSON.dump(message_payload))
   rescue => e
     puts "Release notification to slack failed: #{e.message}"
+  end
+
+  def dashboard_host_name
+    {
+      "production" => "grafana.publishing.service.gov.uk",
+      "staging" => "grafana.staging.publishing.service.gov.uk",
+    }[@environment_name]
   end
 end

--- a/spec/slack_announcer_spec.rb
+++ b/spec/slack_announcer_spec.rb
@@ -32,4 +32,15 @@ RSpec.describe SlackAnnouncer do
     expect(announcer).to receive(:puts).with(/StandardError/)
     expect { announcer.announce("alphagov/whitehall", "Whitehall") }.not_to raise_error
   end
+
+  it "can override the Slack channel" do
+    expect(HTTP).to receive(:post) do |_url, params|
+      expect(JSON.parse(params[:body])).to include(
+        "channel" => "#some_other_channel",
+      )
+    end
+
+    announcer = described_class.new("production", "http://slack.url")
+    announcer.announce("alphagov/whitehall", "Whitehall", "#some_other_channel")
+  end
 end


### PR DESCRIPTION
Link to the new [Grafana dashboards](https://grafana.publishing.service.gov.uk/dashboard/db/prototype-dashboard-whitehall) when the badger deploys Whitehall.

The links are hard-coded because this is the only dashboard we've been working on, but we'll revisit this once we know how application-specific dashboards will work.

Also make the badger Slack channel configurable, which helped us test the change locally but seems like it might be useful to anyone else working on the announcements.

Paired with @dwhenry.

<img width="459" alt="screen shot 2017-04-05 at 16 38 56" src="https://cloud.githubusercontent.com/assets/754712/24713766/7304b4f8-1a1e-11e7-928a-fd9d6ea8f56b.png">

Trello: https://trello.com/c/IcBRUByV/18-add-link-to-dashboards-in-release-app-and-or-badger