### PR TITLE
Remove publishing_api from server_class

### DIFF
--- a/publishing-api/config/deploy.rb
+++ b/publishing-api/config/deploy.rb
@@ -1,6 +1,6 @@
 set :application, "publishing-api"
 set :capfile_dir, File.expand_path('../', File.dirname(__FILE__))
-set :server_class, %w(backend publishing_api)
+set :server_class, %w(backend)
 
 set :run_migrations_by_default, true
 


### PR DESCRIPTION
This causes issues with concurrent migrations, preventing the
Publishing API from being deployed.