### PR TITLE
Revert "Remove publishing_api from server_class"

### DIFF
--- a/publishing-api/config/deploy.rb
+++ b/publishing-api/config/deploy.rb
@@ -1,6 +1,6 @@
 set :application, "publishing-api"
 set :capfile_dir, File.expand_path('../', File.dirname(__FILE__))
-set :server_class, %w(backend)
+set :server_class, %w(backend publishing_api)
 
 set :run_migrations_by_default, true
 


### PR DESCRIPTION
The problem isn't fixed, but adding this back, and then deploying
without migrations might solve the disparity of publishing-api
versions.

This reverts commit 100083a9e6a20e38acd563d875cf54648584ab27.