### PR TITLE
Only one publishing-api server class has db role

### DIFF
--- a/publishing-api/config/deploy.rb
+++ b/publishing-api/config/deploy.rb
@@ -1,6 +1,9 @@
 set :application, "publishing-api"
 set :capfile_dir, File.expand_path('../', File.dirname(__FILE__))
-set :server_class, %w(backend publishing_api)
+set :server_class, {
+  publishing_api: { roles: [:db, :app, :web] },
+  backend: { roles: [:app, :web] },
+}
 
 set :run_migrations_by_default, true
 


### PR DESCRIPTION
By both of these having a db role we end up running migrations on 2
servers simultaneously which causes a "Cannot run migrations because
another migration process is currently running." error.

This doesn't feel an ideal fix as both classes of server will still be
defined with the first item as a primary, which may not be expected
behaviour.