### PR TITLE
Make Badger link to all deployment dashboards

### DIFF
--- a/lib/slack_announcer.rb
+++ b/lib/slack_announcer.rb
@@ -10,7 +10,7 @@ class SlackAnnouncer
     return unless %w(production staging).include?(@environment_name)
 
     text = "<https://github.com/alphagov/#{repo_name}|#{application}> was just deployed to *#{@environment_name}*"
-    if repo_name == "alphagov/whitehall"
+    if repo_name == "whitehall"
       text += "\n:chart_with_upwards_trend: Why not check out the <https://#{dashboard_host_name}/dashboard/db/prototype-dashboard-whitehall|#{application} deployment dashboard>?"
     end
 

--- a/lib/slack_announcer.rb
+++ b/lib/slack_announcer.rb
@@ -37,9 +37,12 @@ class SlackAnnouncer
   end
 
   def dashboard_url(host_name, application_name)
-    url = "https://#{host_name}/api/dashboards/file/deployment_#{application_name}.json"
+    url = "https://grafana.publishing.service.gov.uk/api/dashboards/file/deployment_#{application_name}.json"
     return nil unless (200..399).cover?(HTTP.get(url).code)
 
     "https://#{host_name}/dashboard/file/deployment_#{application_name}.json"
+  rescue => e
+    puts "Unable to connect to grafana server: #{e.message}"
+    nil
   end
 end

--- a/lib/slack_announcer.rb
+++ b/lib/slack_announcer.rb
@@ -10,8 +10,10 @@ class SlackAnnouncer
     return unless %w(production staging).include?(@environment_name)
 
     text = "<https://github.com/alphagov/#{repo_name}|#{application}> was just deployed to *#{@environment_name}*"
-    if repo_name == "whitehall"
-      text += "\n:chart_with_upwards_trend: Why not check out the <https://#{dashboard_host_name}/dashboard/db/prototype-dashboard-whitehall|#{application} deployment dashboard>?"
+
+    url = dashboard_url(dashboard_host_name, repo_name)
+    if url
+      text += "\n:chart_with_upwards_trend: Why not check out the <#{url}|#{application} deployment dashboard>?"
     end
 
     message_payload = {
@@ -32,5 +34,12 @@ class SlackAnnouncer
       "production" => "grafana.publishing.service.gov.uk",
       "staging" => "grafana.staging.publishing.service.gov.uk",
     }[@environment_name]
+  end
+
+  def dashboard_url(host_name, application_name)
+    url = "https://#{host_name}/api/dashboards/file/deployment_#{application_name}.json"
+    return nil unless (200..399).cover?(HTTP.get(url).code)
+
+    "https://#{host_name}/dashboard/file/deployment_#{application_name}.json"
   end
 end

--- a/spec/slack_announcer_spec.rb
+++ b/spec/slack_announcer_spec.rb
@@ -2,6 +2,16 @@ require "spec_helper"
 require "slack_announcer"
 
 RSpec.describe SlackAnnouncer do
+  before do
+    # block requests to external services
+    allow(HTTP).to receive(:get).and_raise(StandardError)
+    allow(HTTP).to receive(:post).and_raise(StandardError)
+
+    allow(HTTP).to receive(:get)
+      .with(%r{grafana.(staging\.|)publishing.service.gov.uk/api/dashboards/file/deployment_.+\.json})
+      .and_return(double(:response, code: 404))
+  end
+
   %w(staging production).each do |environment_name|
     it "annouces a #{environment_name} deploy to slack" do
       expect(HTTP).to receive(:post) do |url, params|
@@ -45,9 +55,12 @@ RSpec.describe SlackAnnouncer do
   end
 
   it "includes dashboard links when dashboard exists in Grafana production deployments" do
-    expected_text = "<https://github.com/alphagov/whitehall|Whitehall> was just deployed to *production*\n" +
-      ":chart_with_upwards_trend: Why not check out the <https://grafana.publishing.service.gov.uk/dashboard/file/deployment_whitehall.json|Whitehall deployment dashboard>?"
+    expected_text = "<https://github.com/alphagov/existing_app|Existing App> was just deployed to *production*\n" +
+      ":chart_with_upwards_trend: Why not check out the <https://grafana.publishing.service.gov.uk/dashboard/file/deployment_existing_app.json|Existing App deployment dashboard>?"
 
+    expect(HTTP).to receive(:get)
+      .with("https://grafana.publishing.service.gov.uk/api/dashboards/file/deployment_existing_app.json")
+      .and_return(double(:response, code: 200))
     expect(HTTP).to receive(:post) do |_url, params|
       expect(JSON.parse(params[:body])).to include(
         "text" => expected_text,
@@ -55,13 +68,16 @@ RSpec.describe SlackAnnouncer do
     end
 
     announcer = described_class.new("production", "http://slack.url")
-    announcer.announce("whitehall", "Whitehall")
+    announcer.announce("existing_app", "Existing App")
   end
 
   it "includes dashboard links when dashboard exists in Grafana staging deployments" do
-    expected_text = "<https://github.com/alphagov/whitehall|Whitehall> was just deployed to *staging*\n" +
-      ":chart_with_upwards_trend: Why not check out the <https://grafana.staging.publishing.service.gov.uk/dashboard/file/deployment_whitehall.json|Whitehall deployment dashboard>?"
+    expected_text = "<https://github.com/alphagov/existing_app|Existing App> was just deployed to *staging*\n" +
+      ":chart_with_upwards_trend: Why not check out the <https://grafana.staging.publishing.service.gov.uk/dashboard/file/deployment_existing_app.json|Existing App deployment dashboard>?"
 
+    expect(HTTP).to receive(:get)
+      .with("https://grafana.staging.publishing.service.gov.uk/api/dashboards/file/deployment_existing_app.json")
+      .and_return(double(:response, code: 200))
     expect(HTTP).to receive(:post) do |_url, params|
       expect(JSON.parse(params[:body])).to include(
         "text" => expected_text,
@@ -69,6 +85,6 @@ RSpec.describe SlackAnnouncer do
     end
 
     announcer = described_class.new("staging", "http://slack.url")
-    announcer.announce("whitehall", "Whitehall")
+    announcer.announce("existing_app", "Existing App")
   end
 end

--- a/spec/slack_announcer_spec.rb
+++ b/spec/slack_announcer_spec.rb
@@ -44,9 +44,9 @@ RSpec.describe SlackAnnouncer do
     announcer.announce("application", "Application", "#some_other_channel")
   end
 
-  it "includes dashboard links in the message for whitehall production deployments" do
+  it "includes dashboard links when dashboard exists in Grafana production deployments" do
     expected_text = "<https://github.com/alphagov/whitehall|Whitehall> was just deployed to *production*\n" +
-      ":chart_with_upwards_trend: Why not check out the <https://grafana.publishing.service.gov.uk/dashboard/db/prototype-dashboard-whitehall|Whitehall deployment dashboard>?"
+      ":chart_with_upwards_trend: Why not check out the <https://grafana.publishing.service.gov.uk/dashboard/file/deployment_whitehall.json|Whitehall deployment dashboard>?"
 
     expect(HTTP).to receive(:post) do |_url, params|
       expect(JSON.parse(params[:body])).to include(
@@ -58,9 +58,9 @@ RSpec.describe SlackAnnouncer do
     announcer.announce("whitehall", "Whitehall")
   end
 
-  it "includes dashboard links in the message for whitehall staging deployments" do
+  it "includes dashboard links when dashboard exists in Grafana staging deployments" do
     expected_text = "<https://github.com/alphagov/whitehall|Whitehall> was just deployed to *staging*\n" +
-      ":chart_with_upwards_trend: Why not check out the <https://grafana.staging.publishing.service.gov.uk/dashboard/db/prototype-dashboard-whitehall|Whitehall deployment dashboard>?"
+      ":chart_with_upwards_trend: Why not check out the <https://grafana.staging.publishing.service.gov.uk/dashboard/file/deployment_whitehall.json|Whitehall deployment dashboard>?"
 
     expect(HTTP).to receive(:post) do |_url, params|
       expect(JSON.parse(params[:body])).to include(

--- a/spec/slack_announcer_spec.rb
+++ b/spec/slack_announcer_spec.rb
@@ -8,13 +8,13 @@ RSpec.describe SlackAnnouncer do
         expect(url).to eq('http://slack.url')
         expect(JSON.parse(params[:body])).to include(
           "username" => "Badger",
-          "text" => "<https://github.com/alphagov/alphagov/application|Application> was just deployed to *#{environment_name}*",
+          "text" => "<https://github.com/alphagov/application|Application> was just deployed to *#{environment_name}*",
           "channel" => "#2ndline",
         )
       end
 
       announcer = described_class.new(environment_name, "http://slack.url")
-      announcer.announce("alphagov/application", "Application")
+      announcer.announce("application", "Application")
     end
   end
 
@@ -22,7 +22,7 @@ RSpec.describe SlackAnnouncer do
     expect(HTTP).not_to receive(:post)
 
     announcer = described_class.new("integration", "http://slack.url")
-    announcer.announce("alphagov/application", "Application")
+    announcer.announce("application", "Application")
   end
 
   it "logs and swallows announcement errors so that the deployment does not fail" do
@@ -30,7 +30,7 @@ RSpec.describe SlackAnnouncer do
 
     announcer = described_class.new("production", "http://slack.url")
     expect(announcer).to receive(:puts).with(/StandardError/)
-    expect { announcer.announce("alphagov/application", "Application") }.not_to raise_error
+    expect { announcer.announce("application", "Application") }.not_to raise_error
   end
 
   it "can override the Slack channel" do
@@ -41,11 +41,11 @@ RSpec.describe SlackAnnouncer do
     end
 
     announcer = described_class.new("production", "http://slack.url")
-    announcer.announce("alphagov/application", "Application", "#some_other_channel")
+    announcer.announce("application", "Application", "#some_other_channel")
   end
 
   it "includes dashboard links in the message for whitehall production deployments" do
-    expected_text = "<https://github.com/alphagov/alphagov/whitehall|Whitehall> was just deployed to *production*\n" +
+    expected_text = "<https://github.com/alphagov/whitehall|Whitehall> was just deployed to *production*\n" +
       ":chart_with_upwards_trend: Why not check out the <https://grafana.publishing.service.gov.uk/dashboard/db/prototype-dashboard-whitehall|Whitehall deployment dashboard>?"
 
     expect(HTTP).to receive(:post) do |_url, params|
@@ -55,11 +55,11 @@ RSpec.describe SlackAnnouncer do
     end
 
     announcer = described_class.new("production", "http://slack.url")
-    announcer.announce("alphagov/whitehall", "Whitehall")
+    announcer.announce("whitehall", "Whitehall")
   end
 
   it "includes dashboard links in the message for whitehall staging deployments" do
-    expected_text = "<https://github.com/alphagov/alphagov/whitehall|Whitehall> was just deployed to *staging*\n" +
+    expected_text = "<https://github.com/alphagov/whitehall|Whitehall> was just deployed to *staging*\n" +
       ":chart_with_upwards_trend: Why not check out the <https://grafana.staging.publishing.service.gov.uk/dashboard/db/prototype-dashboard-whitehall|Whitehall deployment dashboard>?"
 
     expect(HTTP).to receive(:post) do |_url, params|
@@ -69,6 +69,6 @@ RSpec.describe SlackAnnouncer do
     end
 
     announcer = described_class.new("staging", "http://slack.url")
-    announcer.announce("alphagov/whitehall", "Whitehall")
+    announcer.announce("whitehall", "Whitehall")
   end
 end

--- a/spec/slack_announcer_spec.rb
+++ b/spec/slack_announcer_spec.rb
@@ -54,7 +54,7 @@ RSpec.describe SlackAnnouncer do
     announcer.announce("application", "Application", "#some_other_channel")
   end
 
-  it "includes dashboard links when dashboard exists in Grafana production deployments" do
+  it "includes dashboard links for production when dashboard exists in Grafana production deployments" do
     expected_text = "<https://github.com/alphagov/existing_app|Existing App> was just deployed to *production*\n" +
       ":chart_with_upwards_trend: Why not check out the <https://grafana.publishing.service.gov.uk/dashboard/file/deployment_existing_app.json|Existing App deployment dashboard>?"
 
@@ -71,12 +71,12 @@ RSpec.describe SlackAnnouncer do
     announcer.announce("existing_app", "Existing App")
   end
 
-  it "includes dashboard links when dashboard exists in Grafana staging deployments" do
+  it "includes dashboard links for staging when dashboard exists in Grafana production deployments" do
     expected_text = "<https://github.com/alphagov/existing_app|Existing App> was just deployed to *staging*\n" +
       ":chart_with_upwards_trend: Why not check out the <https://grafana.staging.publishing.service.gov.uk/dashboard/file/deployment_existing_app.json|Existing App deployment dashboard>?"
 
     expect(HTTP).to receive(:get)
-      .with("https://grafana.staging.publishing.service.gov.uk/api/dashboards/file/deployment_existing_app.json")
+      .with("https://grafana.publishing.service.gov.uk/api/dashboards/file/deployment_existing_app.json")
       .and_return(double(:response, code: 200))
     expect(HTTP).to receive(:post) do |_url, params|
       expect(JSON.parse(params[:body])).to include(
@@ -85,6 +85,21 @@ RSpec.describe SlackAnnouncer do
     end
 
     announcer = described_class.new("staging", "http://slack.url")
+    announcer.announce("existing_app", "Existing App")
+  end
+
+  it "includes does not include dashboard links when an error occurs connecting to grafana server" do
+    expected_text = "<https://github.com/alphagov/existing_app|Existing App> was just deployed to *production*"
+
+    expect(HTTP).to receive(:get).and_raise(HTTP::ConnectionError)
+    expect(HTTP).to receive(:post) do |_url, params|
+      expect(JSON.parse(params[:body])).to include(
+        "text" => expected_text,
+      )
+    end
+
+    announcer = described_class.new("production", "http://slack.url")
+    expect(announcer).to receive(:puts).with('Unable to connect to grafana server: HTTP::ConnectionError')
     announcer.announce("existing_app", "Existing App")
   end
 end


### PR DESCRIPTION
Makes the dashboard links for all dashboards work

Mobbed with @suzannehamilton @brenetic 

https://trello.com/c/uWEg7LLm/24-add-link-to-all-dashboards-in-release-app-and-badger