### PR TITLE
Fix links from badger announcements to staging dashboards

### DIFF
--- a/lib/slack_announcer.rb
+++ b/lib/slack_announcer.rb
@@ -37,7 +37,7 @@ class SlackAnnouncer
   end
 
   def dashboard_url(host_name, application_name)
-    url = "https://grafana.publishing.service.gov.uk/api/dashboards/file/deployment_#{application_name}.json"
+    url = "https://#{host_name}/api/dashboards/file/deployment_#{application_name}.json"
     return nil unless (200..399).cover?(HTTP.get(url).code)
 
     "https://#{host_name}/dashboard/file/deployment_#{application_name}.json"

--- a/spec/slack_announcer_spec.rb
+++ b/spec/slack_announcer_spec.rb
@@ -54,7 +54,7 @@ RSpec.describe SlackAnnouncer do
     announcer.announce("application", "Application", "#some_other_channel")
   end
 
-  it "includes dashboard links for production when dashboard exists in Grafana production deployments" do
+  it "includes dashboard links for production when dashboard exists" do
     expected_text = "<https://github.com/alphagov/existing_app|Existing App> was just deployed to *production*\n" +
       ":chart_with_upwards_trend: Why not check out the <https://grafana.publishing.service.gov.uk/dashboard/file/deployment_existing_app.json|Existing App deployment dashboard>?"
 
@@ -71,12 +71,12 @@ RSpec.describe SlackAnnouncer do
     announcer.announce("existing_app", "Existing App")
   end
 
-  it "includes dashboard links for staging when dashboard exists in Grafana production deployments" do
+  it "includes dashboard links for staging when dashboard exists" do
     expected_text = "<https://github.com/alphagov/existing_app|Existing App> was just deployed to *staging*\n" +
       ":chart_with_upwards_trend: Why not check out the <https://grafana.staging.publishing.service.gov.uk/dashboard/file/deployment_existing_app.json|Existing App deployment dashboard>?"
 
     expect(HTTP).to receive(:get)
-      .with("https://grafana.publishing.service.gov.uk/api/dashboards/file/deployment_existing_app.json")
+      .with("https://grafana.staging.publishing.service.gov.uk/api/dashboards/file/deployment_existing_app.json")
       .and_return(double(:response, code: 200))
     expect(HTTP).to receive(:post) do |_url, params|
       expect(JSON.parse(params[:body])).to include(


### PR DESCRIPTION
When checking whether a dashboard exists, make an environment-specific request to Grafana rather than only checking Production.

Staging deployments are triggered from the staging environments, so they should call the staging version of Grafana.

https://trello.com/c/uWEg7LLm/24-add-link-to-all-dashboards-in-release-app-and-badger