### PR TITLE
Add deploy_docker task

### DIFF
--- a/recipes/defaults.rb
+++ b/recipes/defaults.rb
@@ -251,3 +251,30 @@ namespace :app do
     hard_restart
   end
 end
+
+namespace :deploy_docker do
+  # These tasks are specific to a docker deployment
+  desc "Deploy the application as a docker image"
+  task :default do
+    pull
+    tag_to_current
+    restart
+  end
+
+  desc "Pull the docker image using a specific tag"
+  task :pull do
+    run "sudo docker image pull #{application}:#{branch}"
+  end
+
+  desc "Tag the image to use the 'current' tag"
+  task :tag_to_current do
+    run "sudo docker image tag #{application}:#{branch} #{application}:current"
+  end
+
+  desc "Restart the docker service for the application"
+  task :restart do
+    run "sudo service docker-#{application} restart"
+  end
+end
+
+after "deploy_docker", "deploy:notify"

--- a/release/Capfile
+++ b/release/Capfile
@@ -4,3 +4,4 @@ $:.unshift(File.expand_path('../../lib', __FILE__))
 load_paths << File.expand_path('../../recipes', __FILE__)
 
 load 'config/deploy'
+load 'config/deploy_docker'

--- a/release/config/deploy_docker.rb
+++ b/release/config/deploy_docker.rb
@@ -1,0 +1,7 @@
+set :application, "release"
+set :capfile_dir, File.expand_path('../', File.dirname(__FILE__))
+set :server_class, "docker-backend"
+
+load 'defaults'
+
+after "deploy:notify", "deploy:notify:errbit"


### PR DESCRIPTION
This allows someone to deploy an app using docker. Assuming that the right tag exists on dockerhub, the task pulls the image, sets it to the application:current tag which is used by our Puppet defined init scripts, and restarts that defined service.