### PR TITLE
Server class should use an underscore

### DIFF
--- a/release/config/deploy_docker.rb
+++ b/release/config/deploy_docker.rb
@@ -1,6 +1,6 @@
 set :application, "release"
 set :capfile_dir, File.expand_path('../', File.dirname(__FILE__))
-set :server_class, "docker-backend"
+set :server_class, "docker_backend"
 
 load 'defaults'
 


### PR DESCRIPTION
```
---> No deploy.sh found, running 'bundle exec cap "deploy_docker"'
+ exec bundle exec cap deploy_docker
    triggering start callbacks for `deploy_docker'
  * executing `deploy:set_servers'
Usage: govuk_node_list [options]

govuk_node_list: error: Node classes should not use hyphens. Hint: Try an underscore
set_servers: no servers with class in '{"docker-backend"=>{:roles=>[:web, :app, :db]}}' in this environment!
Build step 'Execute shell' marked build as failure
```