### PR TITLE
Remove deploy_docker from Capfile

### DIFF
--- a/release/Capfile
+++ b/release/Capfile
@@ -4,4 +4,3 @@ $:.unshift(File.expand_path('../../lib', __FILE__))
 load_paths << File.expand_path('../../recipes', __FILE__)
 
 load 'config/deploy'
-load 'config/deploy_docker'


### PR DESCRIPTION
This is overwriting the servers that we use to release to (so breaks a normal deployment of the release app).