### PR TITLE
Run hard_restart command from restart

### DIFF
--- a/recipes/defaults.rb
+++ b/recipes/defaults.rb
@@ -29,7 +29,7 @@ namespace :deploy do
       migrate
     end
     symlink
-    fetch(:perform_hard_restart, false) ? hard_restart : restart
+    restart
   end
 
   desc "Perform a normal deployment with a hard restart instead of a normal restart"
@@ -67,8 +67,9 @@ namespace :deploy do
   # any schema differences between production and integration
   desc "Migrate database and hard restart the application"
   task :migrate_and_hard_restart, :roles => :app, :except => { :no_release => true } do
+    set :perform_hard_restart, true
     migrate
-    hard_restart
+    restart
   end
 
   task :upload_config, :roles => [:app, :web] do

--- a/recipes/ruby.rb
+++ b/recipes/ruby.rb
@@ -18,16 +18,20 @@ namespace :deploy do
   task :stop do; end
   task :restart, :roles => :app, :max_hosts => 1, :except => { :no_release => true } do
     # The deploy user always has permission to run initctl commands.
-    run "sudo initctl start #{application} 2>/dev/null || sudo initctl reload #{application}"
+    if fetch(:perform_hard_restart, false)
+      # hard-restart is a non-graceful restart of the app.  This has the advantage
+      # of being immediate, and blocking.  Used by some of the post data-syncing
+      # scripts
+      run "sudo initctl start #{application} 2>/dev/null || sudo initctl restart #{application}"
+    else
+      run "sudo initctl start #{application} 2>/dev/null || sudo initctl reload #{application}"
+    end
   end
 
-  # hard-restart is a non-graceful restart of the app.  This has the advantage
-  # of being immediate, and blocking.  Used by some of the post data-syncing
-  # scripts
   desc "A non-graceful restart of the app. Useful for changing ruby version"
-  task :hard_restart, :roles => :app, :max_hosts => 1, :except => { :no_release => true } do
-    # The deploy user always has permission to run initctl commands.
-    run "sudo initctl start #{application} 2>/dev/null || sudo initctl restart #{application}"
+  task :hard_restart do
+    set(:perform_hard_restart, true)
+    restart
   end
 
   task :notify_ruby_version do

--- a/sidekiq-monitoring/config/deploy.rb
+++ b/sidekiq-monitoring/config/deploy.rb
@@ -1,12 +1,8 @@
 set :application, 'sidekiq-monitoring'
 set :capfile_dir, File.expand_path('../', File.dirname(__FILE__))
 set :server_class, 'backend'
+set :perform_hard_restart, true
 
 load 'defaults'
 load 'ruby'
 
-namespace :deploy do
-  task :restart do
-    hard_restart
-  end
-end


### PR DESCRIPTION
If we run hard_restart we have the problem that deploy:restart after
hooks don't get called.

It feels like it's easier to fix this problem with a "deploy:restart"
that gets called whatever restart than it is to set up
"deploy:hard_restart" since "deploy:restart" is such a common hook
point.