### PR TITLE
Switch Slack channel and post on deploy start

### DIFF
--- a/recipes/defaults.rb
+++ b/recipes/defaults.rb
@@ -146,6 +146,7 @@ namespace :deploy do
   end
 end
 
+before "deploy", "deploy:notify:slack_message_start"
 after "deploy", "deploy:notify"
 after "deploy:cold", "deploy:notify"
 after "deploy:migrations", "deploy:notify"

--- a/recipes/notify.rb
+++ b/recipes/notify.rb
@@ -9,7 +9,7 @@ namespace :deploy do
     desc "Notifies external services of a successful deployment"
     task :default do
       release_app
-      slack_message
+      slack_message_done
       graphite_event
     end
 
@@ -48,10 +48,16 @@ namespace :deploy do
       end
     end
 
-    desc "Announce the deploy on Slack"
-    task :slack_message do
+    desc "Announce on Slack the deploy has started"
+    task :slack_message_start do
       annoucer = SlackAnnouncer.new(ENV['ORGANISATION'], ENV['BADGER_SLACK_WEBHOOK_URL'])
-      annoucer.announce(repo_name, application)
+      annoucer.announce_start(repo_name, application)
+    end
+
+    desc "Announce on Slack the deploy has finished"
+    task :slack_message_done do
+      annoucer = SlackAnnouncer.new(ENV['ORGANISATION'], ENV['BADGER_SLACK_WEBHOOK_URL'])
+      annoucer.announce_done(repo_name, application)
     end
 
     desc "Record the deployment as a Graphite event"


### PR DESCRIPTION
We are experimenting with retiring the badger and release calendar and
replacing them with a Slack-based deployment system. This will make
Capistrano post in #govuk-deploy on both start and success of staging
and production deployments.

Also added the version tag being deployed, and an emoji to help
distinguish the environments.

Don't merge until Monday 15th when the experiment is due to start.