### PR TITLE
Install cron configuration for the CPM upon deploy

### DIFF
--- a/content-performance-manager/config/deploy.rb
+++ b/content-performance-manager/config/deploy.rb
@@ -10,5 +10,8 @@ load 'deploy/assets'
 
 load 'govuk_admin_template'
 
+set :whenever_command, "bundle exec whenever"
+require "whenever/capistrano" # This hooks a task to run before deploy:finalize_update
+
 set :rails_env, 'production'
 after "deploy:restart", "deploy:restart_procfile_worker"


### PR DESCRIPTION
Install the cron configuration generated through whenever for the
Content Performance Manager, via capistrano, upon deployment.