### PR TITLE
Reduce noise in deployment announcer

### DIFF
--- a/lib/slack_announcer.rb
+++ b/lib/slack_announcer.rb
@@ -15,12 +15,10 @@ class SlackAnnouncer
   end
 
   def announce_done(repo_name, application, slack_channel = '#govuk-deploy')
-    text = "#{environment_emoji} :white_check_mark: Version #{ENV['TAG']} of <https://github.com/alphagov/#{repo_name}|#{application}> was just deployed to *#{@environment_name}*"
+    text = "#{environment_emoji} :white_check_mark: Version #{ENV['TAG']} of <https://github.com/alphagov/#{repo_name}|#{application}> deployed to *#{@environment_name}*"
 
     url = dashboard_url(dashboard_host_name, repo_name)
-    if url
-      text += "\n:chart_with_upwards_trend: Why not check out the <#{url}|#{application} deployment dashboard>?"
-    end
+    text += " (<#{url}|check dashboard>)" if url
 
     post_text(slack_channel, text)
   end

--- a/spec/slack_announcer_spec.rb
+++ b/spec/slack_announcer_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe SlackAnnouncer do
         expect(url).to eq('http://slack.url')
         expect(JSON.parse(params[:body])).to include(
           "username" => "Badger",
-          "text" => ":govuk-#{environment_name}: :white_check_mark: Version release_123 of <https://github.com/alphagov/application|Application> was just deployed to *#{environment_name}*",
+          "text" => ":govuk-#{environment_name}: :white_check_mark: Version release_123 of <https://github.com/alphagov/application|Application> deployed to *#{environment_name}*",
           "channel" => "#govuk-deploy",
         )
       end
@@ -60,8 +60,7 @@ RSpec.describe SlackAnnouncer do
   end
 
   it "includes dashboard links for production when dashboard exists" do
-    expected_text = ":govuk-production: :white_check_mark: Version release_123 of <https://github.com/alphagov/existing_app|Existing App> was just deployed to *production*\n" +
-      ":chart_with_upwards_trend: Why not check out the <https://grafana.publishing.service.gov.uk/dashboard/file/deployment_existing_app.json|Existing App deployment dashboard>?"
+    expected_text = ":govuk-production: :white_check_mark: Version release_123 of <https://github.com/alphagov/existing_app|Existing App> deployed to *production* (<https://grafana.publishing.service.gov.uk/dashboard/file/deployment_existing_app.json|check dashboard>)"
 
     expect(HTTP).to receive(:get)
       .with("https://grafana.publishing.service.gov.uk/api/dashboards/file/deployment_existing_app.json")
@@ -77,8 +76,7 @@ RSpec.describe SlackAnnouncer do
   end
 
   it "includes dashboard links for staging when dashboard exists" do
-    expected_text = ":govuk-staging: :white_check_mark: Version release_123 of <https://github.com/alphagov/existing_app|Existing App> was just deployed to *staging*\n" +
-      ":chart_with_upwards_trend: Why not check out the <https://grafana.staging.publishing.service.gov.uk/dashboard/file/deployment_existing_app.json|Existing App deployment dashboard>?"
+    expected_text = ":govuk-staging: :white_check_mark: Version release_123 of <https://github.com/alphagov/existing_app|Existing App> deployed to *staging* (<https://grafana.staging.publishing.service.gov.uk/dashboard/file/deployment_existing_app.json|check dashboard>)"
 
     expect(HTTP).to receive(:get)
       .with("https://grafana.staging.publishing.service.gov.uk/api/dashboards/file/deployment_existing_app.json")
@@ -94,7 +92,7 @@ RSpec.describe SlackAnnouncer do
   end
 
   it "includes does not include dashboard links when an error occurs connecting to grafana server" do
-    expected_text = ":govuk-production: :white_check_mark: Version release_123 of <https://github.com/alphagov/existing_app|Existing App> was just deployed to *production*"
+    expected_text = ":govuk-production: :white_check_mark: Version release_123 of <https://github.com/alphagov/existing_app|Existing App> deployed to *production*"
 
     expect(HTTP).to receive(:get).and_raise(HTTP::ConnectionError)
     expect(HTTP).to receive(:post) do |_url, params|
@@ -109,7 +107,7 @@ RSpec.describe SlackAnnouncer do
   end
 
   it "Will only wait for grafana until the timeout is reached before failing the request" do
-    expected_text = ":govuk-production: :white_check_mark: Version release_123 of <https://github.com/alphagov/existing_app|Existing App> was just deployed to *production*"
+    expected_text = ":govuk-production: :white_check_mark: Version release_123 of <https://github.com/alphagov/existing_app|Existing App> deployed to *production*"
 
     expect(HTTP).to receive(:get) do
       sleep 10


### PR DESCRIPTION
* Put deployment notices on one line
* Use less emoji
* Make dashboard link assertive rather than suggestive

![screen shot 2017-05-15 at 11 33 24](https://cloud.githubusercontent.com/assets/319055/26053850/59eef0d8-3962-11e7-9738-35a45dbc7bc4.png)
