### PR TITLE
Add performanceplatform-big-screen-view

### DIFF
--- a/performanceplatform-big-screen-view/Capfile
+++ b/performanceplatform-big-screen-view/Capfile
@@ -1,0 +1,5 @@
+$:.unshift(File.expand_path('../../lib', __FILE__))
+load_paths << File.expand_path('../../recipes', __FILE__)
+
+require 'railsless-deploy'
+load    'config/deploy'

--- a/performanceplatform-big-screen-view/config/deploy.rb
+++ b/performanceplatform-big-screen-view/config/deploy.rb
@@ -1,0 +1,21 @@
+set :application, "performanceplatform-big-screen-view"
+set :server_class, "performance_frontend"
+set :capfile_dir, File.expand_path("../", File.dirname(__FILE__))
+set :shared_children, shared_children + %w(log)
+set :special_route_file, File.dirname(__FILE__) + "/performance_platform_big_screen_view_special_route.json"
+
+load "defaults"
+load "nodejs"
+load "publish_special_routes_non_rails"
+
+namespace :deploy do
+  task :gulp do
+    run "cd #{release_path} && node_modules/gulp/bin/gulp.js production && rm -rf node_modules"
+  end
+
+  task :restart do
+    # nothing
+  end
+end
+
+after "deploy:finalize_update", "deploy:gulp"

--- a/performanceplatform-big-screen-view/config/performance_platform_big_screen_view_special_route.json
+++ b/performanceplatform-big-screen-view/config/performance_platform_big_screen_view_special_route.json
@@ -1,0 +1,16 @@
+{
+  "content_id": "147ff9e0-8f68-4a90-a309-5653422fe187",
+  "format": "special_route",
+  "title": "Performance platform big screen view",
+  "description": "",
+  "routes": [
+    {
+      "path": "/performance/big-screen",
+      "type": "prefix"
+    }
+  ],
+  "publishing_app": "performanceplatform-big-screen-view",
+  "rendering_app": "performanceplatform-big-screen-view",
+  "update_type": "major",
+  "public_updated_at": "2015-09-03T17:00:00+00:00"
+}


### PR DESCRIPTION
Transferred from alphagov-deployment.

We don't need to upload config anymore because the config for dev now matches production and contains no secrets.

Depends on https://github.com/alphagov/performanceplatform-big-screen-view/pull/76.