### PR TITLE
Prevent Content API deployments from running rake

### DIFF
--- a/govuk_content_api/config/deploy.rb
+++ b/govuk_content_api/config/deploy.rb
@@ -14,5 +14,4 @@ set :copy_exclude, [
   'public/templates'
 ]
 
-after "deploy:symlink", "deploy:publishing_api:publish_special_routes"
 after "deploy:notify", "deploy:notify:errbit"


### PR DESCRIPTION
We no longer need to do this as the app is not used anymore. Deployments
are currently failing, so we need this change to deploy it again.

Trello: https://trello.com/c/S5jp2jih/179-setup-technical-implementation-for-a-b-testing-the-blue-box