### PR TITLE
Stop indexing calculators start page.

### DIFF
--- a/calculators/config/deploy.rb
+++ b/calculators/config/deploy.rb
@@ -13,6 +13,5 @@ set :rails_env, 'production'
 set :source_db_config_file, false
 
 after "deploy:upload_initializers", "deploy:symlink_mailer_config"
-after "deploy:symlink", "deploy:rummager:index"
 after "deploy:symlink", "deploy:publishing_api:publish"
 after "deploy:notify", "deploy:notify:errbit"


### PR DESCRIPTION
Related to [Calculators #188](https://github.com/alphagov/calculators/pull/188)

## Description 

This PR removes rummager indexing task, becuase calculators start
page i being migrated to transaction and hence indexing with be handle
but publisher.
