### PR TITLE
Stop indexing licencefinder start page

### DIFF
--- a/licencefinder/config/deploy.rb
+++ b/licencefinder/config/deploy.rb
@@ -20,5 +20,4 @@ set :copy_exclude, [
 ]
 
 after "deploy:upload_initializers", "deploy:symlink_mailer_config"
-after "deploy:symlink", "deploy:rummager:index"
 after "deploy:symlink", "deploy:publishing_api:publish"


### PR DESCRIPTION
Depends on:
* [x] https://github.com/alphagov/licence-finder/pull/104 and https://github.com/alphagov/licence-finder/pull/106 deployed
* [x] Publisher rake tasks in https://github.com/alphagov/publisher/pull/630 run
* [x] New start page in Publisher is published

The page is now served by Frontend and does not need to be indexed by licencefinder.

https://trello.com/c/zboJadd9/409-3-republish-licence-finder-start-page-as-a-transaction-page-and-remove-hardcoded-version