### PR TITLE
Update deployment script for govuk-delivery

### DIFF
--- a/govuk-delivery/config/deploy.rb
+++ b/govuk-delivery/config/deploy.rb
@@ -5,8 +5,6 @@ set :shared_children, shared_children + %w(log)
 
 load "defaults"
 
-set :repository, "#{ENV.fetch('GIT_ORIGIN_PREFIX', 'git@github.gds:gds')}/govuk_delivery.git"
-
 load "python"
 
 namespace :deploy do


### PR DESCRIPTION
`govuk-delivery` has been moved to GitHub.com

Trello: https://trello.com/c/zLOC11AV/23-move-govuk-delivery-from-github-enterprise-to-public-github