### PR TITLE
Remove upload of Redis file

### DIFF
--- a/hmrc-manuals-api/config/deploy.rb
+++ b/hmrc-manuals-api/config/deploy.rb
@@ -5,9 +5,5 @@ set :server_class, "backend"
 load 'defaults'
 load 'ruby'
 
-set :config_files_to_upload, {
-  'secrets/to_upload/redis.yml' => 'config/redis.yml',
-}
-
 after "deploy:restart", "deploy:restart_procfile_worker"
 after "deploy:notify", "deploy:notify:errbit"


### PR DESCRIPTION
Trello: https://trello.com/c/jpPE9GXd

Related to:
1. https://github.digital.cabinet-office.gov.uk/gds/alphagov-deployment/pull/1337
2. https://github.com/alphagov/govuk-puppet/pull/6136
3. https://github.com/alphagov/hmrc-manuals-api/pull/179

## Motivation

Unlike most other GOV.UK applications, HMRC Manuals API used config in [alphagov-deployment](https://github.digital.cabinet-office.gov.uk/gds/alphagov-deployment) to set the values for Redis. 

[alphagov-deployment](https://github.digital.cabinet-office.gov.uk/gds/alphagov-deployment) is an application that has been deprecated, and all config in there should be moved to environment variables.

The config is alphagov-deployment has been removed, so we no longer to copy over values from a config file.