### PR TITLE
Set rsync_options

### DIFF
--- a/recipes/defaults.rb
+++ b/recipes/defaults.rb
@@ -6,6 +6,7 @@ require "slack_announcer"
 set :branch,         ENV["TAG"] ? ENV["TAG"] : "master"
 set :deploy_to,      "/data/apps/#{application}"
 set :deploy_via,     :rsync_with_remote_cache
+set :rsync_options,  ""
 set :organisation,   ENV['ORGANISATION']
 set :keep_releases,  5
 set :rake,           "govuk_setenv #{application} #{fetch(:rake, 'bundle exec rake')}"


### PR DESCRIPTION
## Description 

Following previous PR which introduced a line to exclude test artefacts from being included during deployment. Upon testing on integration we realised that the rsync_option isn't set yet.

This PR sets the rsync options