### PR TITLE
Smart answer: Exclude regression test artefacts

### DIFF
--- a/smartanswers/config/deploy.rb
+++ b/smartanswers/config/deploy.rb
@@ -13,6 +13,8 @@ set :db_config_file, false
 set :rails_env, 'production'
 set :source_db_config_file, false
 
+set :rsync_options, "-az --delete --exclude '.git/' -v --delete-excluded --exclude 'test/artefacts/'"
+
 namespace :deploy do
   task :cold do
     puts "There's no cold task for this project, just deploy normally"


### PR DESCRIPTION
## Description 

The aim of this PR is to avoid syncing the test/artefacts directory from the smart answers project.

This directory contains regression test artefacts that are redundant in production.

These regression test artefacts can be found under a deep directory structure and we believe this slows down the deployment of smart answers.

This PR adds an exclude test/artefacts directory option to the rsync, this will in effect avoid deploying the artefacts directory and
hopefully reduce the taken to deploy smart answers.

Other flag used is the --delete-excluded which ensures that the excluded will be remove from the destination side. Also the -v flag is used to provide feedback.

This PR also sets the rsync options in the default, supplying as default "-az --delete --exclude '.git/'".