### PR TITLE
Draft deployment bugfix

### DIFF
--- a/recipes/set_servers.rb
+++ b/recipes/set_servers.rb
@@ -48,7 +48,7 @@ namespace :deploy do
       end
 
       nodes.each_with_index do |node, index|
-        is_draft_server = !!(node =~ /^draft/)
+        is_draft_server = !!(c =~ /^draft/)
         parent.server node, *extra[:roles], :server_class => c, :primary => (index == 0), :draft => is_draft_server
       end
 


### PR DESCRIPTION
The set servers script depended on the hostname to work out whether a server was a draft machine. In Amazon this is redundant because we do not set hostnames.

Update the script so that we just use the variable we pass to collect the hostnames. This should work in AWS, and should not break current deployments.