### PR TITLE
Configure specialist-publisher for sending email via ses

### DIFF
--- a/specialist-publisher/config/deploy.rb
+++ b/specialist-publisher/config/deploy.rb
@@ -7,5 +7,7 @@ load 'ruby'
 load 'deploy/assets'
 load 'govuk_admin_template'
 
+after "deploy:upload_initializers", "deploy:symlink_mailer_config"
+
 after "deploy:restart", "deploy:restart_procfile_worker"
 after "deploy:notify", "deploy:notify:error_tracker"


### PR DESCRIPTION
For: https://trello.com/c/pk7rYWJ7/210-in-built-report-for-specialist-publisher

We're adding a CSV export function to specialist-publisher, and like
whitehall it's going to email the report to users instead of creating it
and exporting it in the request/response cycle.  It needs this config to
be able to send those emails.

See: https://github.com/alphagov/specialist-publisher/pull/1053