### PR TITLE
Make restarting Procfile workers work properly

### DIFF
--- a/recipes/defaults.rb
+++ b/recipes/defaults.rb
@@ -136,7 +136,7 @@ namespace :deploy do
   desc "Restart the procfile worker"
   task :restart_procfile_worker do
     procfile_worker_name = "#{application}-procfile-worker"
-    run "sudo initctl start #{procfile_worker_name} || sudo initctl restart #{procfile_worker_name}"
+    run "sudo initctl restart #{procfile_worker_name} || sudo initctl start #{procfile_worker_name}"
   end
 
   desc "Not implemented. Falls back to a normal restart"

--- a/rummager/config/deploy.rb
+++ b/rummager/config/deploy.rb
@@ -51,7 +51,7 @@ namespace :deploy do
 
   desc "Restart rummager's publishing-api listener"
   task :restart_publishing_api_listener do
-    run "sudo initctl start rummager-publishing-queue-listener-procfile-worker || sudo initctl restart rummager-publishing-queue-listener-procfile-worker"
+    run "sudo initctl restart rummager-publishing-queue-listener-procfile-worker || sudo initctl start rummager-publishing-queue-listener-procfile-worker"
   end
 end
 

--- a/whitehall/config/deploy.rb
+++ b/whitehall/config/deploy.rb
@@ -92,7 +92,7 @@ namespace :deploy do
   end
 
   task :restart_workers, roles: [:backend], except: { no_release: true } do
-    run "sudo initctl start whitehall-admin-procfile-worker 2>/dev/null || sudo initctl restart whitehall-admin-procfile-worker"
+    run "sudo initctl restart whitehall-admin-procfile-worker || sudo initctl start whitehall-admin-procfile-worker"
   end
 end
 


### PR DESCRIPTION
- We were having problems restarting Procfile workers successfully in
  our new stack on AWS. It was trying to `start` the app's worker on
  deploy, but in most cases it was already running. Therefore, the
  worker exited with 1 because `start` didn't actually start it, yet
  somehow didn't get to to the alternative `restart` command specified
  with `||`. Reversing these - so it first tries to restart, and then if
  that fails, it `start`s. That approach seems to succeed:

  ```
  $ sudo initctl restart transition-procfile-worker || sudo initctl start transition-procfile-worker
  initctl: Unknown instance:
  transition-procfile-worker start/running
  ```

  compared to previously:

  ```
  $ sudo initctl start transition-procfile-worker || sudo initctl restart transition-procfile-worker
  initctl: Job is already running: transition-procfile-worker
  initctl: Job failed to restart
  ```
- This affects all apps that use the default recipe, and some extra ones
  with separate procfile workers for different jobs - rummager and
  whitehall. Whitehall was succeeding because it was sending the error
  output of `start` to `/dev/null`. I've changed this to be consistent
  with the other changes here.