### PR TITLE
Restart Asset Manager sidekiq worker after deployment

### DIFF
--- a/asset-manager/config/deploy.rb
+++ b/asset-manager/config/deploy.rb
@@ -21,4 +21,5 @@ end
 
 after "deploy:update_code", "deploy:create_uploads_symlink"
 after "deploy:restart", "deploy:restart_delayed_job"
+after "deploy:restart", "deploy:restart_procfile_worker"
 after "deploy:notify", "deploy:notify:error_tracker"


### PR DESCRIPTION
Contributes to: https://github.com/alphagov/asset-manager/issues/179

We are migrating asset manager to use sidekiq instead of delayed
job. This ensures the sidekiq workers are restarted after deployment.

This is a companion to [PR 6483](https://github.com/alphagov/govuk-puppet/pull/6483) against `govuk-puppet` which configures the worker processes. 

c.f. https://github.com/alphagov/govuk_sidekiq#5-configure-deployment-scripts