### PR TITLE
Don't copy transition's redis config

### DIFF
--- a/transition/config/deploy.rb
+++ b/transition/config/deploy.rb
@@ -10,10 +10,6 @@ load 'govuk_admin_template'
 
 set :source_db_config_file, 'secrets/to_upload/database.yml'
 
-set :config_files_to_upload, {
-    "secrets/to_upload/redis.yml" => 'config/redis.yml',
-}
-
 set :whenever_command, "bundle exec whenever"
 require "whenever/capistrano" # This hooks a task to run before deploy:finalize_update
 


### PR DESCRIPTION
This was recently removed from alphagov-deployment.

Causes deployment failure:

https://deploy.staging.publishing.service.gov.uk/job/Deploy_App/4609/console