### PR TITLE
Only use URI auth if set

### DIFF
--- a/lib/fetch_build.rb
+++ b/lib/fetch_build.rb
@@ -31,7 +31,9 @@ def setup_http_request(url)
   uri = URI.parse(url)
   Net::HTTP.start(uri.host, uri.port, :use_ssl => uri.scheme == 'https') do |http|
     req = Net::HTTP::Get.new(uri.request_uri)
-    req.basic_auth(uri.user, uri.password)
+    if uri.user && uri.password
+      req.basic_auth(uri.user, uri.password)
+    end
     yield http, req
   end
 end


### PR DESCRIPTION
Previously the `setup_http_request` method always set the user and
password for HTTP requests even if these were set to empty strings or
nil. When accessing resources in S3 this causes a 400 bad request
response as S3 does not support this method of authorisation.

This only sets up basic auth if the user and password are set.