### PR TITLE
Enable asset precompilation for Asset Manager

### DIFF
--- a/asset-manager/config/deploy.rb
+++ b/asset-manager/config/deploy.rb
@@ -5,6 +5,9 @@ set :server_class, "backend"
 load 'defaults'
 load 'ruby'
 
+load 'deploy/assets'
+set :assets_prefix, 'asset-manager'
+
 set :rails_env, 'production'
 
 namespace :deploy do


### PR DESCRIPTION
We're going to want to use Rails asset pipeline assets for the `thumbnail-placeholder.png` image which we're going to move across from Whitehall. See alphagov/asset-manager#200 for details.

I've set the `assets_prefix` to 'asset-manager' to match the value in the Rails app in alphagov/asset-manager#199 and to conform with the approach taken by other apps, e.g. static, so that we'll be able to route requests [via the Nginx configuration for the `assets-origin` host][1].

I plan to test this in integration immediately after it has been merged by triggering an integration deployment and viewing the console output to check the `assets:precompile` Rake task has been run. Even though alpahgov/asset-manager#199 has been merged, the Rails app doesn't currently have any assets, so I won't be able to check I can request an asset at that point.

Closes alpahgov/asset-manager#201.

[1]:
https://github.com/alphagov/govuk-puppet/blob/994d5424c7e4e28e903039f9f603e8d345b4f01d/hieradata/common.yaml#L1545-L1566