### PR TITLE
Fetch the deprecated secrets from GitHub instead of GHE

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,4 +36,4 @@ deploy scripts:
 * `ORGANISATION` - The vCloud organisation being deployed to
 * `CI_DEPLOY_JENKINS_API_KEY` - API key used to fetch build artefacts from ci.dev.publishing.service.gov.uk.
 
-[alphagov-deployment]: https://github.digital.cabinet-office.gov.uk/gds/alphagov-deployment
+[alphagov-deployment]: https://github.com/alphagov/alphagov-deployment

--- a/jenkins.sh
+++ b/jenkins.sh
@@ -6,7 +6,7 @@ cd "$WORKSPACE"
 
 logger -p INFO -t jenkins "DEPLOYMENT: ${JOB_NAME} ${BUILD_NUMBER} ${TARGET_APPLICATION} ${TAG} (${BUILD_URL})"
 
-git clone --depth 1 git@github.digital.cabinet-office.gov.uk:gds/alphagov-deployment.git
+git clone --depth 1 git@github.com:alphagov/alphagov-deployment.git
 
 # If the application doesn't exist in this repo, fall back to
 # alphagov-deployment. FIXME: Remove this when apps have migrated


### PR DESCRIPTION
We’re stopping the use of Github Enterprise, so we need to move
alphagov-deployment to github.com

Take 2 of this PR, was initially requested in #179 and reverted in #181. 

Changed from then to use an SSH-style git URL instead of HTTP, ie with a colon instead of a forward slash.

This has been tested on integration.