### PR TITLE
email-alert-(api|frontend) secrets are now envvars, so don't copy them

### DIFF
--- a/email-alert-api/config/deploy.rb
+++ b/email-alert-api/config/deploy.rb
@@ -9,7 +9,6 @@ load "ruby"
 
 set :config_files_to_upload, {
   "secrets/to_upload/redis.yml" => "config/redis.yml",
-  "secrets/to_upload/secrets.yml" => "config/secrets.yml",
 }
 
 after "deploy:restart", "deploy:restart_procfile_worker"

--- a/email-alert-frontend/config/deploy.rb
+++ b/email-alert-frontend/config/deploy.rb
@@ -10,10 +10,6 @@ set :assets_prefix, 'email-alert-frontend'
 set :source_db_config_file, false
 set :db_config_file, false
 
-set :config_files_to_upload, {
-  'secrets/to_upload/secrets.yml' => 'config/secrets.yml'
-}
-
 set :copy_exclude, [
   '.git/*',
 ]


### PR DESCRIPTION
- As of alphagov-deployment#1355, these files don't exist, so we shouldn't try to copy them on deploy otherwise deploys of these apps fail.