### PR TITLE
Update rummager procfile command order

### DIFF
--- a/rummager/config/deploy.rb
+++ b/rummager/config/deploy.rb
@@ -56,7 +56,7 @@ namespace :deploy do
 
   desc "Restart rummager's publishing-api listener for govuk-index"
   task :restart_published_content_listener do
-    run "sudo initctl start rummager-govuk-index-queue-listener-procfile-worker || sudo initctl restart rummager-govuk-index-queue-listener-procfile-worker"
+    run "sudo initctl restart rummager-govuk-index-queue-listener-procfile-worker || sudo initctl start rummager-govuk-index-queue-listener-procfile-worker"
   end
 end
 


### PR DESCRIPTION
This mirrors the change made in 8160b930bd20cbb644b595d4633d9031a9f9e71b
that helped to resolve errors when performing `start || restart`. Changing
this to `restart || start` will hopefully give a more consistent outcome.

https://trello.com/c/ph0nXo7H/326-intermittent-test-failures