### PR TITLE
Set environment variables when running commands

### DIFF
--- a/mapit/config/deploy.rb
+++ b/mapit/config/deploy.rb
@@ -33,7 +33,7 @@ namespace :deploy do
   end
 
   def run_django_command(command)
-    run "cd #{release_path} && #{shared_path}/venv/bin/python manage.py #{command} --settings=project.settings"
+    run "cd #{release_path} && govuk_setenv #{application} #{shared_path}/venv/bin/python manage.py #{command} --settings=project.settings"
   end
 end
 


### PR DESCRIPTION
Mapit now needs environment variables to be available to be able to talk to the
database.

See: https://deploy.integration.publishing.service.gov.uk/job/Deploy_App/3458/console

https://trello.com/c/ssAr2UCo/160-report-mapit-errors-to-sentry