### PR TITLE
Remove uploading secrets email-alert-*

### DIFF
--- a/email-alert-api/config/deploy.rb
+++ b/email-alert-api/config/deploy.rb
@@ -7,9 +7,5 @@ set :run_migrations_by_default, true
 load "defaults"
 load "ruby"
 
-set :config_files_to_upload, {
-  "secrets/to_upload/redis.yml" => "config/redis.yml",
-}
-
 after "deploy:restart", "deploy:restart_procfile_worker"
 after "deploy:notify", "deploy:notify:error_tracker"

--- a/email-alert-service/config/deploy.rb
+++ b/email-alert-service/config/deploy.rb
@@ -9,9 +9,4 @@ set :copy_exclude, [
   '.git/*',
 ]
 
-set :config_files_to_upload, {
-  "secrets/to_upload/rabbitmq.yml.erb" => "config/rabbitmq.yml",
-  "secrets/to_upload/redis.yml" => "config/redis.yml",
-}
-
 after "deploy:notify", "deploy:notify:error_tracker"


### PR DESCRIPTION
These secrets are now set with env vars in Puppet, so remove the deployment step for uploading them from alphagov-deployment.