### PR TITLE
Remove rummager redis.yml override

### DIFF
--- a/rummager/config/deploy.rb
+++ b/rummager/config/deploy.rb
@@ -11,10 +11,6 @@ require "whenever/capistrano"
 set :source_db_config_file, false
 set :db_config_file, false
 
-set :config_files_to_upload, {
-  "secrets/to_upload/redis.yml" => "config/redis.yml",
-}
-
 set :copy_exclude, [
   '.git/*',
   'public',


### PR DESCRIPTION
Do not override the application configuration, that reads values
from environment variables:
https://github.com/alphagov/rummager/blob/master/config/redis.yml

In addition to:
https://github.com/alphagov/alphagov-deployment/pull/5