### PR TITLE
Restart signon procfile workers

### DIFF
--- a/signon/config/deploy.rb
+++ b/signon/config/deploy.rb
@@ -11,4 +11,5 @@ load 'deploy/assets'
 load 'govuk_admin_template'
 
 after "deploy:upload_initializers", "deploy:symlink_mailer_config"
+after "deploy:restart", "deploy:restart_procfile_worker"
 after "deploy:notify", "deploy:notify:error_tracker"


### PR DESCRIPTION
Workers were not being restarted during the signon deploy causing them to not pick up code changes (e.g. errors still being reported to Errbit when the app has moved to Sentry).

This commit adds an after deploy hook to restart them.