### PR TITLE
Do not start or restart delayed job on asset manager deploy

### DIFF
--- a/asset-manager/config/deploy.rb
+++ b/asset-manager/config/deploy.rb
@@ -15,14 +15,8 @@ namespace :deploy do
   task :create_uploads_symlink do
     run "mkdir -p /data/uploads/asset-manager && ln -sfn /data/uploads/asset-manager #{latest_release}/uploads"
   end
-
-  desc "Restart the delayed_job worker"
-  task :restart_delayed_job do
-    run "sudo initctl start asset-manager-delayed-job-worker || sudo initctl restart asset-manager-delayed-job-worker"
-  end
 end
 
 after "deploy:update_code", "deploy:create_uploads_symlink"
-after "deploy:restart", "deploy:restart_delayed_job"
 after "deploy:restart", "deploy:restart_procfile_worker"
 after "deploy:notify", "deploy:notify:error_tracker"


### PR DESCRIPTION
We have recently removed[1] delayed job from asset manager and
migrated to sidekiq. This commit removes the start/restart task for
asset-manager-delayed-job-worker so that the creation of this upstart
service itself can also be removed from govuk-puppet.

[1] https://github.com/alphagov/asset-manager/pull/232