### PR TITLE
Notify GitHub after router deployments

### DIFF
--- a/router/config/deploy.rb
+++ b/router/config/deploy.rb
@@ -44,3 +44,5 @@ namespace :deploy do
     run "sudo initctl start #{application} 2>/dev/null || sudo initctl reload #{application}"
   end
 end
+
+after "deploy:notify", "deploy:notify:github"


### PR DESCRIPTION
This commit adds a hook to notify GitHub after `router` deployments so that we have the `deployed-to-[integration|staging|production]` branches.