### PR TITLE
Restart Content Performance Manager Sidekiq workers on deployment

### DIFF
--- a/content-performance-manager/config/deploy.rb
+++ b/content-performance-manager/config/deploy.rb
@@ -11,4 +11,22 @@ load 'deploy/assets'
 load 'govuk_admin_template'
 
 set :rails_env, 'production'
-after "deploy:restart", "deploy:restart_procfile_worker"
+
+namespace :deploy do
+  namespace :content_performance_manager do
+    desc "Restart the Google Analytics worker"
+    task :restart_google_analytics_worker do
+      run "sudo initctl restart content-performance-manager-google-analytics-worker-procfile-worker || "\
+          "sudo initctl start content-performance-manager-google-analytics-worker-procfile-worker"
+    end
+
+    desc "Restart the Publishing API worker"
+    task :restart_publishing_api_worker do
+      run "sudo initctl restart content-performance-manager-publishing-api-worker-procfile-worker || "\
+          "sudo initctl start content-performance-manager-publishing-api-worker-procfile-worker"
+    end
+  end
+end
+
+after "deploy:restart", "deploy:content_performance_manager:restart_google_analytics_worker"
+after "deploy:restart", "deploy:content_performance_manager:restart_publishing_api_worker"


### PR DESCRIPTION
We previously made [a change][puppet pr] to instantiate two Sidekiq
workers, rather than one. Each of these has [different settings][config pr]
and different names.

Since we deployed it, the Sidekiq workers have not been restarting on
redeploys, because they do not conform to the
[convention used by `govuk-app-deployment`][deployment convention].

This change adds rake tasks specifically for restarting the Content
Performance Manager workers, and executes them after a restart.

A test run on Integration was performed [here][jenkins]

[puppet pr]: https://github.com/alphagov/govuk-puppet/pull/6526
[config pr]: https://github.com/alphagov/content-performance-manager/pull/361/files
[deployment convention]: https://github.com/alphagov/govuk-app-deployment/blob/fc006f1d4b18b5792e819259273cdafc379f1e21/recipes/defaults.rb#L138
[jenkins]: https://deploy.integration.publishing.service.gov.uk/job/Deploy_App/3861/console