### PR TITLE
Revert "Notify GitHub after router deployments"

### DIFF
--- a/router/config/deploy.rb
+++ b/router/config/deploy.rb
@@ -44,5 +44,3 @@ namespace :deploy do
     run "sudo initctl start #{application} 2>/dev/null || sudo initctl reload #{application}"
   end
 end
-
-after "deploy:notify", "deploy:notify:github"


### PR DESCRIPTION
Reverts alphagov/govuk-app-deployment#196. We don't actually check out the repo on deploy so there's nothing to push.