### PR TITLE
Publish Specialist Publisher special routes on deploy

### DIFF
--- a/specialist-publisher/config/deploy.rb
+++ b/specialist-publisher/config/deploy.rb
@@ -8,5 +8,6 @@ load 'deploy/assets'
 load 'govuk_admin_template'
 
 after "deploy:upload_initializers", "deploy:symlink_mailer_config"
+after "deploy:symlink", "deploy:publishing_api:publish_special_routes"
 
 after "deploy:restart", "deploy:restart_procfile_worker"


### PR DESCRIPTION
We need to publish special routes via a rake task on deploy.

Merge after: https://github.com/alphagov/specialist-publisher/pull/1058

https://trello.com/c/lxKbO5Xw