### PR TITLE
Fix environment variables in rummager cron jobs

### DIFF
--- a/rummager/config/deploy.rb
+++ b/rummager/config/deploy.rb
@@ -5,7 +5,7 @@ set :server_class, "search"
 load 'defaults'
 load 'ruby'
 
-set :whenever_command, "bundle exec whenever"
+set :whenever_command, "govuk_setenv rummager bundle exec whenever"
 require "whenever/capistrano"
 
 set :source_db_config_file, false


### PR DESCRIPTION
Ensure that whenever, which configures the rummager cron tasks, has access to the rummager environment variables when updating the crontab file.

This ensures that the `SITEMAP_GENERATION_TIME` environment variable is available. It ensures that sitemap generation on integration happens at 06:10 UTC, rather than falling back to the default of 01:10 when the integration boxes are switched off.

cc @dwhenry 