### PR TITLE
Copy router artefact to deployed-to-environment

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,5 +11,6 @@ gem "rake"
 gem "whenever", "0.7.3"
 gem "govuk-lint", "~> 1.2"
 gem "http", "~> 2.0"
+gem "aws-sdk-s3"
 
 gem "rspec"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -12,6 +12,19 @@ GEM
     activesupport (3.0.8)
     addressable (2.4.0)
     ast (2.3.0)
+    aws-partitions (1.41.0)
+    aws-sdk-core (3.10.0)
+      aws-partitions (~> 1.0)
+      aws-sigv4 (~> 1.0)
+      jmespath (~> 1.0)
+    aws-sdk-kms (1.3.0)
+      aws-sdk-core (~> 3)
+      aws-sigv4 (~> 1.0)
+    aws-sdk-s3 (1.7.0)
+      aws-sdk-core (~> 3)
+      aws-sdk-kms (~> 1)
+      aws-sigv4 (~> 1.0)
+    aws-sigv4 (1.0.2)
     capistrano (2.9.0)
       highline
       net-scp (>= 1.0.0)
@@ -35,6 +48,7 @@ GEM
       domain_name (~> 0.5)
     http-form_data (1.0.1)
     http_parser.rb (0.6.0)
+    jmespath (1.3.1)
     net-scp (1.0.4)
       net-ssh (>= 1.99.1)
     net-sftp (2.0.5)
@@ -84,6 +98,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  aws-sdk-s3
   capistrano (= 2.9.0)
   capistrano_rsync_with_remote_cache!
   govuk-lint (~> 1.2)
@@ -94,4 +109,4 @@ DEPENDENCIES
   whenever (= 0.7.3)
 
 BUNDLED WITH
-   1.14.5
+   1.16.0

--- a/govuk_crawler_worker/config/deploy.rb
+++ b/govuk_crawler_worker/config/deploy.rb
@@ -22,7 +22,12 @@ namespace :deploy do
     if ENV['USE_S3']
       # Write a file on the remote with the release info
       put "#{ENV['TAG']}\n", "#{release_path}/build_number"
-      artefact_url = "https://#{ENV['S3_ARTEFACT_BUCKET']}.s3.amazonaws.com/#{application}/#{ENV['TAG']}/#{application}"
+
+      bucket = ENV['S3_ARTEFACT_BUCKET']
+      key = "#{application}/#{ENV['TAG']}/#{application}"
+
+      file = fetch_from_s3_to_tempfile(bucket, key)
+      logger.info "Fetching s3://#{bucket}/#{key}"
     else
       ci_base_url = "https://ci_alphagov:#{ENV['CI_DEPLOY_JENKINS_API_KEY']}@ci.integration.publishing.service.gov.uk/job/#{application}/job/master"
       filename = application.to_s
@@ -31,10 +36,10 @@ namespace :deploy do
       # Write a file on the remote with the release info
       put "#{artefact_to_deploy}\n", "#{release_path}/build_number"
       artefact_url = "#{ci_base_url}/#{artefact_to_deploy}/artifact/#{filename}"
+      file = fetch_to_tempfile(artefact_url)
+      logger.info "Fetching #{artefact_url}"
     end
 
-    logger.info "Fetching #{artefact_url}"
-    file = fetch_to_tempfile(artefact_url)
     top.upload file, "#{release_path}/#{application}", :mode => "0755"
   end
 
@@ -43,3 +48,5 @@ namespace :deploy do
     run "sudo initctl start #{application} 2>/dev/null || sudo initctl reload #{application}"
   end
 end
+
+after "deploy:notify", "deploy:notify:copy_artefact"

--- a/lib/fetch_build.rb
+++ b/lib/fetch_build.rb
@@ -1,5 +1,6 @@
 require 'tempfile'
 require 'net/http'
+require 'aws-sdk-s3'
 
 def fetch_last_build_number(base_url)
   number = nil
@@ -24,6 +25,20 @@ def fetch_to_tempfile(url)
     end
   end
   file.rewind
+  file
+end
+
+def fetch_from_s3_to_tempfile(bucket, key)
+  s3 = Aws::S3::Client.new(region: 'eu-west-1')
+  file = Tempfile.new(application.to_s)
+  file.binmode
+
+  object = {
+    :bucket => bucket,
+    :key    => key,
+  }
+
+  s3.get_object(object, target: file)
   file
 end
 

--- a/recipes/notify.rb
+++ b/recipes/notify.rb
@@ -82,5 +82,20 @@ namespace :deploy do
     task :github, :only => { :primary => true } do
       run_locally "cd #{strategy.local_cache_path}; git push -f #{repository} HEAD:refs/heads/deployed-to-#{ENV['ORGANISATION']}"
     end
+
+    desc "Makes a copy of the deployed artefact in the S3 bucket for future deployments"
+    task :copy_artefact do
+      if ENV['USE_S3']
+        s3 = Aws::S3::Client.new(region: 'eu-west-1')
+
+        unless ENV['TAG'] == "deployed-to-#{ENV['ORGANISATION']}"
+          puts "Copying object to deployed-to-#{ENV['ORGANISATION']} branch"
+          s3.copy_object({ :bucket      => ENV['S3_ARTEFACT_BUCKET'],
+                           :key         => "#{application}/#{ENV['TAG']}/#{application}",
+                           :copy_source => "#{ENV['S3_ARTEFACT_BUCKET']}/#{application}/deployed-to-#{ENV['ORGANISATION']}/#{application}"
+          })
+        end
+      end
+    end
   end
 end

--- a/router/config/deploy.rb
+++ b/router/config/deploy.rb
@@ -19,11 +19,15 @@ namespace :deploy do
     on_rollback { run "rm -rf #{release_path}; true" }
     run "mkdir -p #{release_path}"
 
-
     if ENV['USE_S3']
       # Write a file on the remote with the release info
       put "#{ENV['TAG']}\n", "#{release_path}/build_number"
-      artefact_url = "https://#{ENV['S3_ARTEFACT_BUCKET']}.s3.amazonaws.com/#{application}/#{ENV['TAG']}/#{application}"
+
+      bucket = ENV['S3_ARTEFACT_BUCKET']
+      key = "#{application}/#{ENV['TAG']}/#{application}"
+
+      file = fetch_from_s3_to_tempfile(bucket, key)
+      logger.info "Fetching s3://#{bucket}/#{key}"
     else
       ci_base_url = "https://ci_alphagov:#{ENV['CI_DEPLOY_JENKINS_API_KEY']}@ci.integration.publishing.service.gov.uk/job/#{application}/job/master"
       filename = application.to_s
@@ -32,10 +36,10 @@ namespace :deploy do
       # Write a file on the remote with the release info
       put "#{artefact_to_deploy}\n", "#{release_path}/build_number"
       artefact_url = "#{ci_base_url}/#{artefact_to_deploy}/artifact/#{filename}"
+      file = fetch_to_tempfile(artefact_url)
+      logger.info "Fetching #{artefact_url}"
     end
 
-    logger.info "Fetching #{artefact_url}"
-    file = fetch_to_tempfile(artefact_url)
     top.upload file, "#{release_path}/#{application}", :mode => "0755"
   end
 
@@ -44,3 +48,5 @@ namespace :deploy do
     run "sudo initctl start #{application} 2>/dev/null || sudo initctl reload #{application}"
   end
 end
+
+after "deploy:notify", "deploy:notify:copy_artefact"


### PR DESCRIPTION
In AWS we're using this branch to guess what version of the app to deploy.

For Router this is not possible because we're just pulling an artefact, rather than a Github repository.

Copy the released artefact to the name of the thing we're trying to deploy.

Related to https://github.com/alphagov/govuk-aws/pull/382