### PR TITLE
Ignore host key verification

### DIFF
--- a/recipes/defaults.rb
+++ b/recipes/defaults.rb
@@ -12,7 +12,7 @@ set :rake,           "govuk_setenv #{application} #{fetch(:rake, 'bundle exec ra
 set :repo_name,      fetch(:repo_name, application).to_s # XXX: this must appear before the `require 'defaults' in recipe names
 set :repository,     "#{ENV.fetch('GIT_ORIGIN_PREFIX', 'git@github.com:alphagov')}/#{repo_name}.git"
 set :scm,            :git
-set :ssh_options,    { :forward_agent => true, :keys => "#{ENV['HOME']}/.ssh/id_rsa" }
+set :ssh_options,    { :forward_agent => true, :keys => "#{ENV['HOME']}/.ssh/id_rsa", :paranoid => false }
 set :use_sudo,       false
 set :user,           "deploy"
 set :dockerhub_repo, "govuk"

--- a/recipes/docker.rb
+++ b/recipes/docker.rb
@@ -1,6 +1,6 @@
 # Deploy docker applications
 #
-set :ssh_options,    { :forward_agent => true, :keys => "#{ENV['HOME']}/.ssh/id_rsa" }
+set :ssh_options,    { :forward_agent => true, :keys => "#{ENV['HOME']}/.ssh/id_rsa", :paranoid => false }
 set :use_sudo,       false
 set :user,           "deploy"
 set :dockerhub_repo, "govuk"


### PR DESCRIPTION
There is a file `/etc/ssh/ssh_known_hosts` that is managed by puppet and
contains the ssh host keys for all hosts on the system. Unfortunately,
setting the capistrano ssh option `global_known_hosts_file` does not use
this file and will still append hosts to the jenkins users known hosts
file, which is not managed by puppet.

In AWS, when a new machine comes up, capistrano will without asking for
verification add this machines host key into the jenkins users known
hosts file. However, if a new machine comes up with an ip address that
is already in the user known hosts file, the host key will not match and
this will cause a deployment error.

Although it feels wrong to ignore the host key, currently when a new
machine comes up it is silently added to the jenkins users ssh
known_hosts file, so if a rogue host on the network came up we would
deploy to it anyway.

For reference the net ssh options capistrano uses are here -
https://net-ssh.github.io/ssh/v2/api/classes/Net/SSH.html#M000002