### PR TITLE
Allow hard restart for Whitehall

### DIFF
--- a/whitehall/config/deploy.rb
+++ b/whitehall/config/deploy.rb
@@ -85,11 +85,19 @@ namespace :deploy do
   end
 
   task :restart_frontend, roles: [:frontend], except: { no_release: true } do
-    run "sudo initctl start whitehall 2>/dev/null || sudo initctl reload whitehall"
+    if fetch(:perform_hard_restart, false)
+      run "sudo initctl start whitehall 2>/dev/null || sudo initctl restart whitehall"
+    else
+      run "sudo initctl start whitehall 2>/dev/null || sudo initctl reload whitehall"
+    end
   end
 
   task :restart_backend, roles: [:backend], except: { no_release: true } do
-    run "sudo initctl start whitehall 2>/dev/null || sudo initctl reload whitehall"
+    if fetch(:perform_hard_restart, false)
+      run "sudo initctl start whitehall 2>/dev/null || sudo initctl restart whitehall"
+    else
+      run "sudo initctl start whitehall 2>/dev/null || sudo initctl reload whitehall"
+    end
   end
 
   task :restart_workers, roles: [:backend], except: { no_release: true } do


### PR DESCRIPTION
Whitehall ❄️ overrides the `restart` task when deploying to restart on backend and frontend apps.

The default `restart` task has a "hard restart" option that restarts the applications entirely: https://github.com/alphagov/govuk-app-deployment/blob/b3ac799139555f308b6f5503972e9c93b072f4a4/recipes/ruby.rb#L19-L29

This commit adds that for Whitehall to so that we can do a hard restart to make it pick up a new Ruby version.