### PR TITLE
Remove rumager:index task from post deploy for migrated apps

### DIFF
--- a/calendars/config/deploy.rb
+++ b/calendars/config/deploy.rb
@@ -17,5 +17,4 @@ namespace :deploy do
   end
 end
 
-after "deploy:symlink", "deploy:rummager:index"
 after "deploy:symlink", "deploy:publishing_api:publish"

--- a/smartanswers/config/deploy.rb
+++ b/smartanswers/config/deploy.rb
@@ -21,5 +21,4 @@ namespace :deploy do
   end
 end
 
-after "deploy:symlink", "deploy:rummager:index"
 after "deploy:symlink", "deploy:publishing_api:publish"


### PR DESCRIPTION
Calendars and Smart answers now index data into rummager via the publishing
API son this task causes build failures.

https://trello.com/c/2g1qysaD/509-remove-rummager-integration-from-calendars
https://trello.com/c/6YLtQotp/517-remove-rummager-code-from-smart-answers