### PR TITLE
Remove non-existent rummager task

### DIFF
--- a/frontend/config/deploy.rb
+++ b/frontend/config/deploy.rb
@@ -25,6 +25,5 @@ namespace :deploy do
 end
 
 after "deploy:symlink", "deploy:publishing_api:publish_special_routes"
-after "deploy:symlink", "deploy:rummager:index"
 
 before "deploy:assets:precompile", "deploy:mustache_precompile"


### PR DESCRIPTION
This task was removed in https://github.com/alphagov/frontend/pull/1349 and
breaks the deployment unless we remove it from here.