### PR TITLE
Revert upgrades

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source "http://rubygems.org/"
 
-gem "capistrano", "~> 2.15"
+gem "capistrano", "2.9.0"
 gem "capistrano_rsync_with_remote_cache",
   :git => "https://github.com/alphagov/capistrano_rsync_with_remote_cache",
   :tag => "v2.4.1"

--- a/Gemfile
+++ b/Gemfile
@@ -8,7 +8,7 @@ gem "capistrano_rsync_with_remote_cache",
 gem "railsless-deploy", :require => false
 
 gem "rake"
-gem "whenever", "0.10.0"
+gem "whenever", "0.7.3"
 gem "govuk-lint", "~> 3.4"
 gem "http", "~> 3.0"
 gem "aws-sdk-s3"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -40,7 +40,7 @@ GEM
       net-sftp (>= 2.0.0)
       net-ssh (>= 2.0.14)
       net-ssh-gateway (>= 1.1.0)
-    chronic (0.10.2)
+    chronic (0.6.7)
     concurrent-ruby (1.0.5)
     diff-lcs (1.3)
     domain_name (0.5.20170404)
@@ -131,8 +131,9 @@ GEM
       unf_ext
     unf_ext (0.0.7.4)
     unicode-display_width (1.3.0)
-    whenever (0.10.0)
-      chronic (>= 0.6.3)
+    whenever (0.7.3)
+      activesupport (>= 2.3.4)
+      chronic (~> 0.6.3)
 
 PLATFORMS
   ruby
@@ -146,7 +147,7 @@ DEPENDENCIES
   railsless-deploy
   rake
   rspec
-  whenever (= 0.10.0)
+  whenever (= 0.7.3)
 
 BUNDLED WITH
    1.16.0

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -34,7 +34,7 @@ GEM
       aws-sdk-kms (~> 1)
       aws-sigv4 (~> 1.0)
     aws-sigv4 (1.0.2)
-    capistrano (2.15.9)
+    capistrano (2.9.0)
       highline
       net-scp (>= 1.0.0)
       net-sftp (>= 2.0.0)
@@ -139,7 +139,7 @@ PLATFORMS
 
 DEPENDENCIES
   aws-sdk-s3
-  capistrano (~> 2.15)
+  capistrano (= 2.9.0)
   capistrano_rsync_with_remote_cache!
   govuk-lint (~> 3.4)
   http (~> 3.0)


### PR DESCRIPTION
This is causing us problems with deploying apps, hopefully this should fix it.

We upgraded `whenever` as dependabot noticed it was out of date, this was causing problems with builds as it was using a method only available in versions of `capistrano` after 2.9 and we were using exactly `2.9.0`. We decided upgrading `capistrano` might help, but that's broken the deploys in a different way because it now looks for `manifest*` files which don't exist. It seems like the only quick way to fix this, for now, is to not upgrade `capistrano` and `whenever`.