### PR TITLE
Change hardcoded graphite hostname to an envvar

### DIFF
--- a/recipes/notify.rb
+++ b/recipes/notify.rb
@@ -73,7 +73,7 @@ namespace :deploy do
                      tags: "#{application} #{ENV['ORGANISATION']} deploys",
                      data: "#{branch} #{current_revision[0, 7]} #{ENV['BUILD_USER']}" }.to_json
         req.basic_auth(ENV['GRAPHITE_USER'], ENV['GRAPHITE_PASSWORD'])
-        Net::HTTP.new('graphite.cluster', '80').start { |http| http.request(req) }
+        Net::HTTP.new(ENV['GRAPHITE_HOST'], '80').start { |http| http.request(req) }
       rescue => e
         puts "Graphite notification failed: #{e.message}"
       end


### PR DESCRIPTION
- In AWS, the deploy app jobs were failing to talk to Graphite because of a non-existent `graphite.cluster` hostname. Use an envvar instead (set in alphagov/govuk-puppet#7027).