### PR TITLE
Fix net-ssh deprecation warning

### DIFF
--- a/recipes/defaults.rb
+++ b/recipes/defaults.rb
@@ -12,7 +12,7 @@ set :rake,           "govuk_setenv #{application} #{fetch(:rake, 'bundle exec ra
 set :repo_name,      fetch(:repo_name, application).to_s # XXX: this must appear before the `require 'defaults' in recipe names
 set :repository,     "#{ENV.fetch('GIT_ORIGIN_PREFIX', 'git@github.com:alphagov')}/#{repo_name}.git"
 set :scm,            :git
-set :ssh_options,    { :forward_agent => true, :keys => "#{ENV['HOME']}/.ssh/id_rsa", :paranoid => false }
+set :ssh_options,    { :forward_agent => true, :keys => "#{ENV['HOME']}/.ssh/id_rsa", :verify_host_key => false }
 set :use_sudo,       false
 set :user,           "deploy"
 set :dockerhub_repo, "govuk"

--- a/recipes/docker.rb
+++ b/recipes/docker.rb
@@ -1,6 +1,6 @@
 # Deploy docker applications
 #
-set :ssh_options,    { :forward_agent => true, :keys => "#{ENV['HOME']}/.ssh/id_rsa", :paranoid => false }
+set :ssh_options,    { :forward_agent => true, :keys => "#{ENV['HOME']}/.ssh/id_rsa", :verify_host_key => false }
 set :use_sudo,       false
 set :user,           "deploy"
 set :dockerhub_repo, "govuk"


### PR DESCRIPTION
When we deploy our apps we get the following deprecation warning:

> :paranoid is deprecated, please use :verify_host_key. Supported values are exactly the same, only the name of the option has changed. :paranoid is deprecated, please use :verify_host_key. Supported values are exactly the same, only the name of the option has changed.

This is from the net-ssh gem which indicates that `:paranoid` is a [deprecated alias][1] for `:verify_host_key` so we should be able to safely interchange them.

[1]: https://github.com/net-ssh/net-ssh/blob/c43fc3ade9337fa6688019b8baf2a2288105b272/lib/net/ssh.rb#L160