### PR TITLE
Change hardcoded graphite port to an envvar

### DIFF
--- a/recipes/notify.rb
+++ b/recipes/notify.rb
@@ -73,7 +73,7 @@ namespace :deploy do
                      tags: "#{application} #{ENV['ORGANISATION']} deploys",
                      data: "#{branch} #{current_revision[0, 7]} #{ENV['BUILD_USER']}" }.to_json
         req.basic_auth(ENV['GRAPHITE_USER'], ENV['GRAPHITE_PASSWORD'])
-        Net::HTTP.new(ENV['GRAPHITE_HOST'], '80').start { |http| http.request(req) }
+        Net::HTTP.new(ENV['GRAPHITE_HOST'], ENV['GRAPHITE_PORT']).start { |http| http.request(req) }
       rescue => e
         puts "Graphite notification failed: #{e.message}"
       end


### PR DESCRIPTION
- The port on AWS is 443 whereas on Carrenza it's 80, so switch to
  envvars (where the default is 80, as in https://github.com/alphagov/govuk-puppet/pull/7049).