### PR TITLE
Remove mustache steps from frontend

### DIFF
--- a/frontend/config/deploy.rb
+++ b/frontend/config/deploy.rb
@@ -18,12 +18,4 @@ set :copy_exclude, [
   'public/templates'
 ]
 
-namespace :deploy do
-  task :mustache_precompile do
-    run "cd #{latest_release} && #{rake} shared_mustache:compile --trace"
-  end
-end
-
 after "deploy:symlink", "deploy:publishing_api:publish_special_routes"
-
-before "deploy:assets:precompile", "deploy:mustache_precompile"


### PR DESCRIPTION
Mustache was removed from frontend in https://github.com/alphagov/frontend/pull/1376 and we're now getting a lovely error when deploying:

> 13:07:38   * executing `deploy:mustache_precompile'
> 13:07:38   * executing "cd /data/apps/frontend/releases/20180111130733 && govuk_setenv frontend bundle exec rake shared_mustache:compile --trace"
13:07:40 *** [err ] rake aborted!
13:07:40 *** [err ] Don't know how to build task 'shared_mustache:compile' (see --tasks)