### PR TITLE
Allow docker tagging for deploy by artefact projects

### DIFF
--- a/govuk_crawler_worker/config/deploy.rb
+++ b/govuk_crawler_worker/config/deploy.rb
@@ -49,4 +49,4 @@ namespace :deploy do
   end
 end
 
-after "deploy:notify", "deploy:notify:copy_artefact"
+after "deploy:notify", "deploy:notify:copy_artefact", "deploy:notify:docker"

--- a/lib/docker_tag_pusher.rb
+++ b/lib/docker_tag_pusher.rb
@@ -14,6 +14,17 @@ class DockerTagPusher
     @password = password
   end
 
+  def has_repo?(repo)
+    request = Net::HTTP::Get.new(
+      "#{REGISTRY}/v2/#{repo}/tags/list?n=1",
+      'Authorization' => "Bearer #{token(repo)}",
+    )
+    response = registry_client.request(request)
+    raise "Error (#{response.code}) checking repo exists: #{response.body}" unless %w[200 404].include?(response.code)
+
+    response.code == '200'
+  end
+
   def get_manifest(repo, tag)
     request = Net::HTTP::Get.new(
       "#{REGISTRY}/v2/#{repo}/manifests/#{tag}",

--- a/lib/docker_tag_pusher.rb
+++ b/lib/docker_tag_pusher.rb
@@ -23,8 +23,8 @@ class DockerTagPusher
     response = registry_client.request(request)
 
     raise 'Image or tag not found' if response.code == '404'
+    raise "Error (#{response.code}) while fetching manifest: #{response.body}" if response.code != '200'
     raise "Remote image not in correct format (must be #{MEDIA_TYPE})" if response['Content-Type'] != MEDIA_TYPE
-    raise "Server error while fetching manifest: #{response.body}" if response.code != '200'
 
     response.body
   end

--- a/router/config/deploy.rb
+++ b/router/config/deploy.rb
@@ -49,4 +49,4 @@ namespace :deploy do
   end
 end
 
-after "deploy:notify", "deploy:notify:copy_artefact"
+after "deploy:notify", "deploy:notify:copy_artefact", "deploy:notify:docker"

--- a/spec/docker_tag_pusher_spec.rb
+++ b/spec/docker_tag_pusher_spec.rb
@@ -9,6 +9,41 @@ RSpec.describe DockerTagPusher do
       allow(instance).to receive(:token).with('govuk/publishing-api') { 'bazqux' }
     end
 
+    describe "#has_repo?" do
+      before do
+        stub_request(
+          :get,
+          'https://registry-1.docker.io/v2/govuk/publishing-api/tags/list?n=1'
+        ).with(headers: {
+          'Authorization' => 'Bearer bazqux',
+        }).to_return(status: status)
+      end
+
+      context "when a repo exists" do
+        let(:status) { 200 }
+
+        it "returns true" do
+          expect(instance.has_repo?('govuk/publishing-api')).to be true
+        end
+      end
+
+      context "when a repo doesn't exist" do
+        let(:status) { 404 }
+
+        it "returns false" do
+          expect(instance.has_repo?('govuk/publishing-api')).to be false
+        end
+      end
+
+      context "when an error occurs" do
+        let(:status) { 401 }
+
+        it "raises an error" do
+          expect { instance.has_repo?('govuk/publishing-api') }.to raise_error(/Error \(401\) checking repo exists/)
+        end
+      end
+    end
+
     describe '#get_manifest' do
       context 'when an image is found' do
         it 'returns the manifest as a string' do

--- a/spec/docker_tag_pusher_spec.rb
+++ b/spec/docker_tag_pusher_spec.rb
@@ -42,6 +42,20 @@ RSpec.describe DockerTagPusher do
         end
       end
 
+      context 'when an error occurs accessing the image' do
+        it 'raises an error' do
+          stub_request(
+            :get,
+            'https://registry-1.docker.io/v2/govuk/publishing-api/manifests/master'
+          ).with(headers: {
+            'Authorization' => 'Bearer bazqux',
+            'Accept' => 'application/vnd.docker.distribution.manifest.v2+json'
+          }).to_return(status: 401)
+
+          expect { instance.get_manifest('govuk/publishing-api', 'master') }.to raise_error(/Error \(401\) while fetching manifest/)
+        end
+      end
+
       context 'when the image is in the wrong format' do
         it 'raises an error' do
           stub_request(


### PR DESCRIPTION
This changes the approach we used to determine whether we will attempt to tag a Docker image or not as part of a deployment.

Previously we relied on the presence of a Dockerfile in the source code to judge whether we should tag. This did not work for situations where we are deploying artefacts, as these have no source code available to check. Instead this has the approach of querying whether there are already tags on the docker registry or not. 
