### PR TITLE
Task to git tag a release for an artefact release

### DIFF
--- a/recipes/notify.rb
+++ b/recipes/notify.rb
@@ -84,6 +84,16 @@ namespace :deploy do
       run_locally "cd #{strategy.local_cache_path}; git push -f #{repository} HEAD:refs/heads/deployed-to-#{ENV['ORGANISATION']}"
     end
 
+    task :git_clone_and_tag, :only => { :primary => true } do
+      path = strategy.local_cache_path
+      if File.exist?(path)
+        run_locally source.sync(branch, path)
+      else
+        run_locally "mkdir -p #{path} && #{source.checkout(revision, path)}"
+      end
+      notify.github
+    end
+
     task :docker, only: { primary: true } do
       if !ENV['DOCKER_HUB_USERNAME'] || !ENV['DOCKER_HUB_PASSWORD']
         # note the DOCKER TAG FAILED component is matched with Jenkins to set build status, change it with caution

--- a/router/config/deploy.rb
+++ b/router/config/deploy.rb
@@ -49,4 +49,4 @@ namespace :deploy do
   end
 end
 
-after "deploy:notify", "deploy:notify:copy_artefact", "deploy:notify:docker"
+after "deploy:notify", "deploy:notify:copy_artefact", "deploy:notify:git_clone_and_tag", "deploy:notify:docker"


### PR DESCRIPTION
Repos which are deployed via artefact such as router lack the consistent
deployed-to-* branches that are present on all our non-artefact
branches. This does a clone of the repo for that artefact and tags it.

As far as I could tell there wasn't a way to do this without a git
clone.