### PR TITLE
Fix router deploy for branch

### DIFF
--- a/recipes/notify.rb
+++ b/recipes/notify.rb
@@ -86,8 +86,9 @@ namespace :deploy do
 
     task :git_clone_and_tag, :only => { :primary => true } do
       path = strategy.local_cache_path
+      revision = source.query_revision(branch) { |cmd| run_locally cmd }
       if File.exist?(path)
-        run_locally source.sync(branch, path)
+        run_locally source.sync(revision, path)
       else
         run_locally "mkdir -p #{path} && #{source.checkout(revision, path)}"
       end


### PR DESCRIPTION
Turns out that passing a branch name is not ideal as this only works
when the branch is actually a tag. When it is just a branch this fails.

Instead we can use the query_revision method to get a commit sha hash
and use that for the clone instead.

Can see an example of this running successfully here: https://deploy.integration.publishing.service.gov.uk/job/Deploy_App/1081/ 