### PR TITLE
Add deployment scripts for Content Audit Tool

### DIFF
--- a/content-audit-tool/Capfile
+++ b/content-audit-tool/Capfile
@@ -1,0 +1,6 @@
+load 'deploy'
+
+$:.unshift(File.expand_path('../../lib', __FILE__))
+load_paths << File.expand_path('../../recipes', __FILE__)
+
+load 'config/deploy'

--- a/content-audit-tool/config/deploy.rb
+++ b/content-audit-tool/config/deploy.rb
@@ -1,0 +1,32 @@
+set :application, "content-audit-tool"
+set :capfile_dir, File.expand_path('../', File.dirname(__FILE__))
+set :server_class, "backend"
+
+set :run_migrations_by_default, true
+
+load 'defaults'
+load 'ruby'
+load 'deploy/assets'
+
+load 'govuk_admin_template'
+
+set :rails_env, 'production'
+
+namespace :deploy do
+  namespace :content_audit_tool do
+    desc "Restart the Google Analytics worker"
+    task :restart_google_analytics_worker do
+      run "sudo initctl restart content-audit-tool-google-analytics-worker-procfile-worker || "\
+          "sudo initctl start content-audit-tool-google-analytics-worker-procfile-worker"
+    end
+
+    desc "Restart the Publishing API worker"
+    task :restart_publishing_api_worker do
+      run "sudo initctl restart content-audit-tool-publishing-api-worker-procfile-worker || "\
+          "sudo initctl start content-audit-tool-publishing-api-worker-procfile-worker"
+    end
+  end
+end
+
+after "deploy:restart", "deploy:content_audit_tool:restart_google_analytics_worker"
+after "deploy:restart", "deploy:content_audit_tool:restart_publishing_api_worker"


### PR DESCRIPTION
We are splitting out the Audit Tool from the Content Performance
Manager.

I have not yet configured the credentials for Google Analytics API or the Publishing API, so the tasks to restart those jobs are commented out for now.