### PR TITLE
Configure email-alert-api deployments with whenever

### DIFF
--- a/email-alert-api/config/deploy.rb
+++ b/email-alert-api/config/deploy.rb
@@ -7,4 +7,7 @@ set :run_migrations_by_default, true
 load "defaults"
 load "ruby"
 
+set :whenever_command, "govuk_setenv email-alert-api bundle exec whenever"
+require "whenever/capistrano"
+
 after "deploy:restart", "deploy:restart_procfile_worker"


### PR DESCRIPTION
Email Alert API is now using Whenever to schedule tasks so we need to configure the deployment to enable it.