### PR TITLE
Deploy email-alert-api and email-alert-service to own machines

### DIFF
--- a/email-alert-api/config/deploy.rb
+++ b/email-alert-api/config/deploy.rb
@@ -1,6 +1,6 @@
 set :application, "email-alert-api"
 set :capfile_dir, File.expand_path("../", File.dirname(__FILE__))
-set :server_class, "backend"
+set :server_class, %w(email_alert_api backend)
 
 set :run_migrations_by_default, true
 

--- a/email-alert-service/config/deploy.rb
+++ b/email-alert-service/config/deploy.rb
@@ -1,6 +1,6 @@
 set :application, "email-alert-service"
 set :capfile_dir, File.expand_path('../', File.dirname(__FILE__))
-set :server_class, "backend"
+set :server_class, %w(email_alert_api backend)
 
 load 'defaults'
 load 'ruby'


### PR DESCRIPTION
This commit changes email-alert-api and email-alert-service to deploy to their own dedicated machines.

Depends on https://github.com/alphagov/govuk-puppet/pull/7285.

Trello: https://trello.com/c/oqi6Xvnu/629-move-email-alert-api-and-email-alert-service-to-dedicated-vms