### PR TITLE
Stop deploying email alert apps to backend servers

### DIFF
--- a/email-alert-api/config/deploy.rb
+++ b/email-alert-api/config/deploy.rb
@@ -1,6 +1,6 @@
 set :application, "email-alert-api"
 set :capfile_dir, File.expand_path("../", File.dirname(__FILE__))
-set :server_class, %w(email_alert_api backend)
+set :server_class, "email_alert_api"
 
 set :run_migrations_by_default, true
 

--- a/email-alert-service/config/deploy.rb
+++ b/email-alert-service/config/deploy.rb
@@ -1,6 +1,6 @@
 set :application, "email-alert-service"
 set :capfile_dir, File.expand_path('../', File.dirname(__FILE__))
-set :server_class, %w(email_alert_api backend)
+set :server_class, "email_alert_api"
 
 load 'defaults'
 load 'ruby'


### PR DESCRIPTION
This commit stops email-alert-api and email-alert-service from being deployed to backend servers since they have been migrated to their own servers.

Trello: https://trello.com/c/oqi6Xvnu/629-move-email-alert-api-and-email-alert-service-to-dedicated-vms