### PR TITLE
Modify Deploy_Apps S3 Artefact Copying

### DIFF
--- a/recipes/notify.rb
+++ b/recipes/notify.rb
@@ -138,11 +138,12 @@ namespace :deploy do
         s3 = Aws::S3::Client.new(region: 'eu-west-1')
 
         unless ENV['TAG'] == "deployed-to-#{ENV['ORGANISATION']}"
-          puts "Copying object to deployed-to-#{ENV['ORGANISATION']} branch"
-          s3.copy_object({ :bucket      => ENV['S3_ARTEFACT_BUCKET'],
-                           :key         => "#{application}/#{ENV['TAG']}/#{application}",
-                           :copy_source => "#{ENV['S3_ARTEFACT_BUCKET']}/#{application}/deployed-to-#{ENV['ORGANISATION']}/#{application}"
-          })
+          source_key = "#{application}/#{ENV['TAG']}/#{application}"
+          target_key = "#{application}/deployed-to-#{ENV['ORGANISATION']}/#{application}"
+          s3.copy_object({ :bucket => ENV['S3_ARTEFACT_BUCKET'],
+                           :copy_source => ENV['S3_ARTEFACT_BUCKET'] + '/' + source_key,
+                           :key => target_key })
+          puts "Copying file #{source_key} to #{target_key}."
         end
       end
     end


### PR DESCRIPTION
- We noticed an issue where the process of copying a release artefact to
  a secondary location was failing with an error similar to
'Aws::S3::Errors::NoSuchKey'. We then identified that this is related to
a feature associated to the copy_object class method. Within this
method, we were using the 'copy_source'. According to the documentation,
the source need a single explicit slash. Without this character the
operation fails.

 - Documentation -
   https://docs.aws.amazon.com/sdkforruby/api/Aws/S3/Client.html#copy_object-instance_method

Solo: @suthagarht