### PR TITLE
Change the github tagging for crawler

### DIFF
--- a/govuk_crawler_worker/config/deploy.rb
+++ b/govuk_crawler_worker/config/deploy.rb
@@ -49,5 +49,4 @@ namespace :deploy do
   end
 end
 
-after "deploy:notify", "deploy:notify:copy_artefact", "deploy:notify:docker"
-after "deploy:notify", "deploy:notify:github"
+after "deploy:notify", "deploy:notify:copy_artefact", "deploy:notify:git_clone_and_tag", "deploy:notify:docker"


### PR DESCRIPTION
This was set to use the notify:github command which relies on a local
clone of the application which is not the case with an artefact based
deploy.

This instead uses the git_clone_and_tag approach which is intended for
archive based deployments.

@dwhenry this should fix the issues we were seeing today.