### PR TITLE
Don't publish content on deploy of Frontend

### DIFF
--- a/frontend/config/deploy.rb
+++ b/frontend/config/deploy.rb
@@ -17,5 +17,3 @@ set :copy_exclude, [
   'public/stylesheets',
   'public/templates'
 ]
-
-after "deploy:symlink", "deploy:publishing_api:publish_special_routes"


### PR DESCRIPTION
This is unnecessary most of the time, and can cause a large amount of
unnecessary Publishing API activity (through dependency
resolution). This rake task should be run manually when a change is
made to the content which is published.

You can track activity back through dependency resolution to the source in the logs. This is a visualisation of that data. Frontend through repeatedly publishing the homepage is the biggest culprit.

![dependency-resolution-activity](https://user-images.githubusercontent.com/1130010/37671208-23c06e2a-2c63-11e8-952f-a23395facfe2.png)
