### PR TITLE
Add restart publishing-api bulk import consumer

### DIFF
--- a/content-performance-manager/config/deploy.rb
+++ b/content-performance-manager/config/deploy.rb
@@ -31,9 +31,16 @@ namespace :deploy do
       run "sudo initctl restart content-performance-manager-publishing-api-consumer-procfile-worker ||"\
           "sudo initctl start content-performance-manager-publishing-api-consumer-procfile-worker"
     end
+
+    desc "Restart the Publishing API bulk import consumer"
+    task :restart_publishing_api_bulk_import_consumer do
+      run "sudo initctl restart content-performance-manager-publishing-api-consumer-procfile-workerbulk-import-consumer ||"\
+          "sudo initctl start content-performance-manager-publishing-api-consumer-procfile-workerbulk-import-consumer"
+    end
   end
 end
 
 after "deploy:restart", "deploy:content_performance_manager:restart_google_analytics_worker"
 after "deploy:restart", "deploy:content_performance_manager:restart_publishing_api_worker"
 after "deploy:restart", "deploy:content_performance_manager:restart_publishing_api_consumer"
+after "deploy:restart", "deploy:content_performance_manager:restart_publishing_api_bulk_import_consumer"


### PR DESCRIPTION
Content Performance Manager is subscribed to changes in Publishing API
via a consumer of a Rabbit MQ queue. It is necessary then to restart the
consumer each time the application is restarted.

The queue has a specific routing key, so messages come through to the
just this consumer when we run a bulk import.