### PR TITLE
Rename procfile worker restart command

### DIFF
--- a/content-performance-manager/config/deploy.rb
+++ b/content-performance-manager/config/deploy.rb
@@ -34,8 +34,8 @@ namespace :deploy do
 
     desc "Restart the Publishing API bulk import consumer"
     task :restart_publishing_api_bulk_import_consumer do
-      run "sudo initctl restart content-performance-manager-publishing-api-consumer-procfile-worker-bulk-import-consumer ||"\
-          "sudo initctl start content-performance-manager-publishing-api-consumer-procfile-worker-bulk-import-consumer"
+      run "sudo initctl restart content-performance-manager-bulk-import-publishing-api-consumer-procfile-worker ||"\
+          "sudo initctl start content-performance-manager-bulk-import-publishing-api-consumer-procfile-worker"
     end
   end
 end


### PR DESCRIPTION
To match what the Procfile worker is defined as in puppet.

See https://github.com/alphagov/govuk-puppet/pull/7583