### PR TITLE
Send SHA & user to Release app

### DIFF
--- a/recipes/notify.rb
+++ b/recipes/notify.rb
@@ -33,9 +33,12 @@ namespace :deploy do
             conn.use_ssl = true
 
             form_data = {
-              "repo"                    => repository,
-              "deployment[version]"     => ENV['TAG'],
-              "deployment[environment]" => organisation
+              "repo" => repository,
+              "deployment[environment]" => organisation,
+              "deployment[jenkins_user_email]" => ENV['BUILD_USER_EMAIL'],
+              "deployment[jenkins_user_name]" => ENV['BUILD_USER'],
+              "deployment[deployed_sha]" => current_revision,
+              "deployment[version]" => ENV['TAG'],
             }
             request.set_form_data(form_data)
             request["Accept"] = "application/json"


### PR DESCRIPTION
This sends additional info the the release app:

- the SHA of what we're actually committing
- the user name and email of the person deploying

This will allow us to show the user on a deploy page, and have better insight to what we actually deployed. This is especially useful in cases where branches are deployed by name, which can obviously change.

Release app hasn't been updated to persist this data, that will be done in a future PR.