### PR TITLE
Send deployed SHA to Release app

### DIFF
--- a/recipes/notify.rb
+++ b/recipes/notify.rb
@@ -32,12 +32,14 @@ namespace :deploy do
             conn = Net::HTTP.new(url.host, url.port)
             conn.use_ssl = true
 
+            deployed_sha = run_locally("git rev-list -n 1 #{current_revision}")
+
             form_data = {
               "repo" => repository,
               "deployment[environment]" => organisation,
               "deployment[jenkins_user_email]" => ENV['BUILD_USER_EMAIL'],
               "deployment[jenkins_user_name]" => ENV['BUILD_USER'],
-              "deployment[deployed_sha]" => current_revision,
+              "deployment[deployed_sha]" => deployed_sha,
               "deployment[version]" => ENV['TAG'],
             }
             request.set_form_data(form_data)


### PR DESCRIPTION
`current_revision` is a SHA that points to the tag that is being released. For example, for the latest deploy to production of this app, the current revision that was sent to the Release app was `3c829e70e0c392528ca91536f1b8a70eea97500a`:

```
$ git show-ref --tags | grep "refs/tags/release_321" 3c829e70e0c392528ca91536f1b8a70eea97500a refs/tags/release_321
```

This commit isn't linkable on GitHub:

https://github.com/alphagov/release/commit/3c829e70e0c392528ca91536f1b8a70eea97500a (404)

We can get the actual commit that was deployed by running `git rev-list -n 1`:

Which provides the correct linkable SHA:

```
$ git rev-list -n 1 3c829e70e0c392528ca91536f1b8a70eea97500a
7511aaea59a328b78a4ad20f644a928e4231cb06
```

https://github.com/alphagov/release/commit/7511aaea59a328b78a4ad20f644a928e4231cb06