### PR TITLE
Revert "Send deployed SHA to Release app"

### DIFF
--- a/recipes/notify.rb
+++ b/recipes/notify.rb
@@ -32,14 +32,12 @@ namespace :deploy do
             conn = Net::HTTP.new(url.host, url.port)
             conn.use_ssl = true
 
-            deployed_sha = run_locally("git rev-list -n 1 #{current_revision}")
-
             form_data = {
               "repo" => repository,
               "deployment[environment]" => organisation,
               "deployment[jenkins_user_email]" => ENV['BUILD_USER_EMAIL'],
               "deployment[jenkins_user_name]" => ENV['BUILD_USER'],
-              "deployment[deployed_sha]" => deployed_sha,
+              "deployment[deployed_sha]" => current_revision,
               "deployment[version]" => ENV['TAG'],
             }
             request.set_form_data(form_data)


### PR DESCRIPTION
This doesn't work: https://deploy.publishing.service.gov.uk/job/Deploy_App/6067/console

Reverts alphagov/govuk-app-deployment#265