### PR TITLE
Fix content-publisher deploy

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,8 +32,6 @@ load 'deploy/assets'
 set :copy_exclude, [
   '.git/*'
 ]
-
-after "deploy:restart"
 ```
 
 ## How deployments work

--- a/content-publisher/config/deploy.rb
+++ b/content-publisher/config/deploy.rb
@@ -9,5 +9,3 @@ load 'deploy/assets'
 set :copy_exclude, [
   '.git/*'
 ]
-
-after "deploy:restart"


### PR DESCRIPTION
https://trello.com/c/CPWJzL9y/5-create-skeleton-rails-app

The 'after' hook was only necessary to ensure the ordering of an extra
step, such as restarting a worker process; the deploy:restart task will
always run.