### PR TITLE
Run migrations by default

### DIFF
--- a/content-publisher/config/deploy.rb
+++ b/content-publisher/config/deploy.rb
@@ -2,6 +2,8 @@ set :application, "content-publisher"
 set :capfile_dir, File.expand_path('../', File.dirname(__FILE__))
 set :server_class, "backend"
 
+set :run_migrations_by_default, true
+
 load 'defaults'
 load 'ruby'
 load 'deploy/assets'


### PR DESCRIPTION
This is what all other apps do. Without this, integration migrations will never be run.