### PR TITLE
Rename procfile worker to fit with name in puppet

### DIFF
--- a/content-performance-manager/config/deploy.rb
+++ b/content-performance-manager/config/deploy.rb
@@ -34,8 +34,8 @@ namespace :deploy do
 
     desc "Restart the Publishing API bulk import consumer"
     task :restart_publishing_api_bulk_import_consumer do
-      run "sudo initctl restart content-performance-manager-bulk-import-publishing-api-consumer-procfile-worker ||"\
-          "sudo initctl start content-performance-manager-bulk-import-publishing-api-consumer-procfile-worker"
+      run "sudo initctl restart cpm-bulk-import-publishing-api-consumer-procfile-worker ||"\
+          "sudo initctl start cpm-bulk-import-publishing-api-consumer-procfile-worker"
     end
   end
 end


### PR DESCRIPTION
We need to rename the procfile worker name because we have renamed it in
puppet[1] in order to create an alert in the number of threads of
profile workers[2]

[1]: https://github.com/alphagov/govuk-puppet/pull/7808
[2]: https://github.com/alphagov/govuk-puppet/pull/7775