### PR TITLE
Reduces the number of releases we keep

### DIFF
--- a/recipes/defaults.rb
+++ b/recipes/defaults.rb
@@ -7,7 +7,7 @@ set :branch,         ENV["TAG"] ? ENV["TAG"] : "master"
 set :deploy_to,      "/data/apps/#{application}"
 set :deploy_via,     :rsync_with_remote_cache
 set :organisation,   ENV['ORGANISATION']
-set :keep_releases,  5
+set :keep_releases,  2
 set :rake,           "govuk_setenv #{application} #{fetch(:rake, 'bundle exec rake')}"
 set :repo_name,      fetch(:repo_name, application).to_s # XXX: this must appear before the `require 'defaults' in recipe names
 set :repository,     "#{ENV.fetch('GIT_ORIGIN_PREFIX', 'git@github.com:alphagov')}/#{repo_name}"


### PR DESCRIPTION
https://trello.com/c/cdC5XUYD/237-cleanup-old-app-releases-to-save-disk

Each release costs disk space and can vary from a couple of Megabytes to
several hundred. The purpose of storing releases on the machine is to
enable fast rollback without having to re-deploy the app. Having 2
releases should be sufficient to preserve this facility and means we can
avoid resizing the disks, as they are currently nearing capacity.