### PR TITLE
Lowercase AWS suffix for Release app notifications

### DIFF
--- a/recipes/notify.rb
+++ b/recipes/notify.rb
@@ -33,7 +33,7 @@ namespace :deploy do
             conn.use_ssl = true
 
             deployed_to_environment = if ENV['USE_S3'] == 'true' && ENV['ORGANISATION'] != 'integration'
-                                        "#{ENV['ORGANISATION']}-AWS"
+                                        "#{ENV['ORGANISATION']}-aws"
                                       else
                                         ENV['ORGANISATION']
                                       end


### PR DESCRIPTION
This makes it consistent with other environment names.

Trello: https://trello.com/c/aAwyrVNx/606-enable-release-app-notifications-in-aws