### PR TITLE
Ignore error message from govuk_node_list

### DIFF
--- a/recipes/set_servers.rb
+++ b/recipes/set_servers.rb
@@ -38,7 +38,7 @@ namespace :deploy do
     classes.each_pair do |c, extra|
       begin
         # Fetch list of available nodes from govuk_node_list command
-        nodes = %x{govuk_node_list -c "#{c}"}.split
+        nodes = %x{govuk_node_list -c "#{c}" 2> /dev/null}.split
       rescue Errno::ENOENT
         raise CommandError.new("set_servers: govuk_node_list is not available!")
       end


### PR DESCRIPTION
SNIMissingWarning errors are being consumed by a set_servers function. Sending
the error to /dev/null should eliminate this issue allow the script to continue
onto the next steps.

Co-authored-by: Roch Trinque <roch.trinque@digital.cabinet-office.gov.uk>