### PR TITLE
Set default build user

### DIFF
--- a/lib/slack_announcer.rb
+++ b/lib/slack_announcer.rb
@@ -11,7 +11,7 @@ class SlackAnnouncer
 
   def announce_start(repo_name, application, slack_channel = '#govuk-deploy')
     text = "#{environment_emoji} :mega: #{version_and_link(repo_name, application)} " \
-           "is being deployed to *#{@environment_name}* by #{ENV['BUILD_USER']}"
+           "is being deployed to *#{@environment_name}* by #{build_user}"
 
     url = dashboard_url(dashboard_host_name, repo_name)
     text += " (<#{url}|check dashboard>)" if url
@@ -21,7 +21,7 @@ class SlackAnnouncer
 
   def announce_done(repo_name, application, slack_channel = '#govuk-deploy')
     text = "#{environment_emoji} :white_check_mark: #{version_and_link(repo_name, application)} " \
-           "deployed to *#{@environment_name}* by #{ENV['BUILD_USER']}"
+           "deployed to *#{@environment_name}* by #{build_user}"
 
     post_text(slack_channel, text)
   end
@@ -52,6 +52,10 @@ class SlackAnnouncer
 
   def environment_emoji
     ":govuk-#{@environment_name}:"
+  end
+
+  def build_user
+    ENV.fetch('BUILD_USER', 'Jenkins')
   end
 
   def dashboard_host_name


### PR DESCRIPTION
This commit sets a default build user of “Jenkins” when no actual build user name is available. This usually happens when a new AWS EC2 instance is created and the `Deploy_Node_Apps` Jenkins job initiates deployments of all relevant apps to that instance.