### PR TITLE
add a revision file for router app

### DIFF
--- a/recipes/notify.rb
+++ b/recipes/notify.rb
@@ -38,7 +38,11 @@ namespace :deploy do
                                         ENV['ORGANISATION']
                                       end
 
-            deployed_sha = run_locally("cd #{strategy.local_cache_path} && git rev-list -n 1 #{current_revision}")
+            deployed_sha = if ENV['USE_S3'] == 'false'
+                             run_locally("cd #{strategy.local_cache_path} && git rev-list -n 1 #{current_revision}")
+                           else
+                             "from_s3"
+                           end
 
             form_data = {
               "repo" => repository,

--- a/recipes/notify.rb
+++ b/recipes/notify.rb
@@ -41,7 +41,7 @@ namespace :deploy do
             deployed_sha = if ENV['USE_S3'] == 'false'
                              run_locally("cd #{strategy.local_cache_path} && git rev-list -n 1 #{current_revision}")
                            else
-                             "from_s3"
+                             ENV['FILE_SHA256']
                            end
 
             form_data = {

--- a/router/config/deploy.rb
+++ b/router/config/deploy.rb
@@ -23,6 +23,9 @@ namespace :deploy do
       # Write a file on the remote with the release info
       put "#{ENV['TAG']}\n", "#{release_path}/build_number"
 
+      # Write a file on the remote with the revision info
+      put "release_#{ENV['TAG']}\n", "#{release_path}/REVISION"
+
       bucket = ENV['S3_ARTEFACT_BUCKET']
       key = "#{application}/#{ENV['TAG']}/#{application}"
 

--- a/router/config/deploy.rb
+++ b/router/config/deploy.rb
@@ -1,4 +1,5 @@
 require 'fetch_build'
+require 'digest'
 
 set :application, "router"
 set :capfile_dir, File.expand_path('../', File.dirname(__FILE__))
@@ -23,9 +24,6 @@ namespace :deploy do
       # Write a file on the remote with the release info
       put "#{ENV['TAG']}\n", "#{release_path}/build_number"
 
-      # Write a file on the remote with the revision info
-      put "release_#{ENV['TAG']}\n", "#{release_path}/REVISION"
-
       bucket = ENV['S3_ARTEFACT_BUCKET']
       key = "#{application}/#{ENV['TAG']}/#{application}"
 
@@ -42,6 +40,11 @@ namespace :deploy do
       file = fetch_to_tempfile(artefact_url)
       logger.info "Fetching #{artefact_url}"
     end
+
+    # Write a file on the remote with the revision info, i.e sha256 of file
+    file_sha256 = Digest::SHA256.file file.path
+    ENV['FILE_SHA256'] = file_sha256.hexdigest
+    put "#{file_sha256.hexdigest}\n", "#{release_path}/REVISION"
 
     top.upload file, "#{release_path}/#{application}", :mode => "0755"
   end


### PR DESCRIPTION
# Context

The app-deployment main workflow assumes that the app is retrieved via github but for router app this is done via a S3 bucket which contains the binary. 

The notification workflow assumes that there is a file called REVISION which contains the git commit hash of the repo of the app being deployed. Since this is not available for apps residing in S3 buckets, we calculate the sha256 of the app file and use it instead.

# Decision
1. in `config/deploy.rb`, we calculate the sha256 of the file retrieved and then we put it into an env variable and the REVISION file mention above.
2. This env variable value is used in `recipes/notify.rb` as the `deployed_sha` used for notifying the release app.
