### PR TITLE
Hard restart the cache clearing service

### DIFF
--- a/cache-clearing-service/config/deploy.rb
+++ b/cache-clearing-service/config/deploy.rb
@@ -1,6 +1,7 @@
 set :application, "cache-clearing-service"
 set :capfile_dir, File.expand_path('../', File.dirname(__FILE__))
 set :server_class, "backend"
+set :perform_hard_restart, true
 
 load 'defaults'
 load 'ruby'


### PR DESCRIPTION
It doesn't respond well to `reload`, and there's no great need for it to exit gracefully (if it even can).

https://trello.com/c/qBtWYsPC/717-speed-up-cache-clearing-service