### PR TITLE
Set a custom repository for the Content Data API

### DIFF
--- a/content-data-api/config/deploy.rb
+++ b/content-data-api/config/deploy.rb
@@ -1,7 +1,7 @@
 set :application, "content-data-api"
 set :capfile_dir, File.expand_path('../', File.dirname(__FILE__))
 set :server_class, "backend"
-
+set :repository, "git@github.com/alphagov/content-performance-manager.git"
 set :run_migrations_by_default, true
 
 load 'defaults'


### PR DESCRIPTION
This name of the Content Performance Manager is being changed, so this
will allow deploying the Content Performance Manager as the Content
Data API during the migration.