### PR TITLE
Add restart hook for Content Publisher

### DIFF
--- a/content-publisher/config/deploy.rb
+++ b/content-publisher/config/deploy.rb
@@ -11,3 +11,5 @@ load 'deploy/assets'
 set :copy_exclude, [
   '.git/*'
 ]
+
+after "deploy:restart", "deploy:restart_procfile_worker"


### PR DESCRIPTION
For https://trello.com/c/rXTLvzSu/685-scheduling-is-sent-to-the-publishing-api