### PR TITLE
Adds a sidekiq worker to content data admin

### DIFF
--- a/content-data-admin/config/deploy.rb
+++ b/content-data-admin/config/deploy.rb
@@ -11,3 +11,5 @@ load 'deploy/assets'
 set :copy_exclude, [
   '.git/*'
 ]
+
+after "deploy:restart", "deploy:restart_procfile_worker"


### PR DESCRIPTION
Deploys of the Content Data Admin now starts a Sidekiq worker. This is need for the worker process used to send emails for CSV downloads.