### PR TITLE
Enable mailer config for Content Data Admin

### DIFF
--- a/content-data-admin/config/deploy.rb
+++ b/content-data-admin/config/deploy.rb
@@ -13,3 +13,4 @@ set :copy_exclude, [
 ]
 
 after "deploy:restart", "deploy:restart_procfile_worker"
+after "deploy:upload_initializers", "deploy:symlink_mailer_config"


### PR DESCRIPTION
This symlinks the mailer config generated by puppet into the Content Data Admin initialisers. This is to set the smtp settings for ActionMailer.