### PR TITLE
Remove 'deploy/assets' and 'govuk_admin_template'

### DIFF
--- a/content-data-api/config/deploy.rb
+++ b/content-data-api/config/deploy.rb
@@ -7,9 +7,6 @@ set :run_migrations_by_default, true
 
 load 'defaults'
 load 'ruby'
-load 'deploy/assets'
-
-load 'govuk_admin_template'
 
 set :rails_env, 'production'
 

--- a/content-performance-manager/config/deploy.rb
+++ b/content-performance-manager/config/deploy.rb
@@ -6,9 +6,6 @@ set :run_migrations_by_default, true
 
 load 'defaults'
 load 'ruby'
-load 'deploy/assets'
-
-load 'govuk_admin_template'
 
 set :rails_env, 'production'
 


### PR DESCRIPTION
From the Content Performance Manager and Content Data API deployment
scripts, as these are now unnecessary.