### PR TITLE
Use whenever with the Publishing API

### DIFF
--- a/publishing-api/config/deploy.rb
+++ b/publishing-api/config/deploy.rb
@@ -7,4 +7,7 @@ set :run_migrations_by_default, true
 load 'defaults'
 load 'ruby'
 
+set :whenever_command, "bundle exec whenever"
+require "whenever/capistrano"
+
 after "deploy:restart", "deploy:restart_procfile_worker"


### PR DESCRIPTION
The Publishing API has had the configuration for using whenever since
2015, and it's supposed to send heartbeat RabbitMQ messages. But this
doesn't seem to be happening, and I believe this is because whenever
isn't generating the necessary cron configuration.

Maybe this was done in some previous deployment configuration...