### PR TITLE
Stop copying business finder shared config

### DIFF
--- a/email-alert-api/config/deploy.rb
+++ b/email-alert-api/config/deploy.rb
@@ -2,8 +2,6 @@ set :application, "email-alert-api"
 set :capfile_dir, File.expand_path("../", File.dirname(__FILE__))
 set :server_class, "email_alert_api"
 
-set :do_upload_shared_config, true
-
 set :run_migrations_by_default, true
 
 load "defaults"

--- a/recipes/ruby.rb
+++ b/recipes/ruby.rb
@@ -56,15 +56,6 @@ namespace :deploy do
     end
   end
 
-  task :upload_shared_config do
-    config_folder = File.expand_path("../secrets/shared_config/", Dir.pwd)
-    if fetch(:do_upload_shared_config, false) && File.exist?(config_folder)
-      Dir.glob(File.join(config_folder, "*")).each do |config|
-        top.upload(config, File.join(release_path, "config/#{File.basename(config)}"))
-      end
-    end
-  end
-
   task :upload_organisation_config do
     config_folder = File.expand_path("secrets/to_upload/config/#{ENV['ORGANISATION']}", Dir.pwd)
     if File.exist?(config_folder)
@@ -90,6 +81,6 @@ end
 
 after "deploy:update_code", "deploy:notify_ruby_version"
 after "deploy:finalize_update", "deploy:upload_initializers"
-after "deploy:upload_config", "deploy:upload_shared_config", "deploy:upload_organisation_config"
+after "deploy:upload_config", "deploy:upload_organisation_config"
 after "deploy:upload_initializers", "deploy:upload_organisation_initializers"
 after "deploy:notify", "deploy:notify:github", "deploy:notify:docker"

--- a/search-api/config/deploy.rb
+++ b/search-api/config/deploy.rb
@@ -4,8 +4,6 @@ set :application, "search-api"
 set :capfile_dir, File.expand_path('../', File.dirname(__FILE__))
 set :server_class, "search"
 
-set :do_upload_shared_config, true
-
 load 'defaults'
 load 'ruby'
 


### PR DESCRIPTION
Trello: 
* https://trello.com/c/T2ibAO7v
* https://trello.com/c/EiqPAgCD

## Motivation

The config for the business readiness finder needed to be kept in one place, because it was needed by both email-alert-api and search-api to support the old way of tagging to the business finder. Only search-api needs this config now to publish the finder so we can remove the tasks that copy the config from the "secrets" repo.

This is the first step towards archiving the "secrets" repo

