### PR TITLE
Restart CKAN harvest processes after CKAN deploy

### DIFF
--- a/ckan/config/deploy.rb
+++ b/ckan/config/deploy.rb
@@ -23,6 +23,18 @@ namespace :deploy do
   task :install_package, roles: :app do
     run "cd #{release_path} && '#{virtualenv_path}/bin/python' #{release_path}/setup.py install"
   end
+
+  desc "Restart harvest gather process"
+  task :restart_harvest_gather_process do
+    run "sudo initctl restart harvester_gather_consumer-procfile-worker || sudo initctl start harvester_gather_consumer-procfile-worker"
+  end
+
+  desc "Restart harvest fetch process"
+  task :restart_harvest_fetch_process do
+    run "sudo initctl restart harvester_fetch_consumer-procfile-worker || sudo initctl start harvester_fetch_consumer-procfile-worker"
+  end
 end
 
 after "deploy:create_symlink", "deploy:install_package"
+after "deploy:restart", "deploy:restart_harvest_gather_process"
+after "deploy:restart", "deploy:restart_harvest_fetch_process"


### PR DESCRIPTION
## What

Restart the harvest fetch and gather process for each CKAN deployment.

## Why 

Currently any changes that affect the harvest processes mean that a dev will have to log onto the box and restart the processes in each environment, the processes should probably be restarted each time theres  a new deploy to ensure that the processes are using the latest code and so that devs no longer need to log into the boxes.