### PR TITLE
Remove the configuration for the content-performance-manager repo

### DIFF
--- a/content-data-api/config/deploy.rb
+++ b/content-data-api/config/deploy.rb
@@ -1,5 +1,4 @@
 set :application, "content-data-api"
-set :repo_name, 'content-performance-manager'
 set :capfile_dir, File.expand_path('../', File.dirname(__FILE__))
 set :server_class, "backend"
 


### PR DESCRIPTION
This should be merged once the git repository has been renamed.

The Git repository is being renamed, so remove the now unnecessary
configuration.