### PR TITLE
Remove shared mustache compile step in finder-frontend

### DIFF
--- a/finder-frontend/config/deploy.rb
+++ b/finder-frontend/config/deploy.rb
@@ -15,9 +15,6 @@ namespace :deploy do
   task :cold do
     puts "There's no cold task for this project, just deploy normally"
   end
-  task :mustache_precompile do
-    run "cd #{latest_release} && #{rake} shared_mustache:compile --trace"
-  end
 end
 
-before "deploy:assets:precompile", "deploy:mustache_precompile"
+before "deploy:assets:precompile"


### PR DESCRIPTION
Mustache rendering was removed in finder-frontend, so this step
is no longer needed.

github: https://github.com/alphagov/finder-frontend/pull/1066
trello: https://trello.com/c/mkyenxJy/680-remove-sharedmustache-dependency