### PR TITLE
Add unpublishing queue consumer restart script

### DIFF
--- a/email-alert-service/config/deploy.rb
+++ b/email-alert-service/config/deploy.rb
@@ -8,3 +8,15 @@ load 'ruby'
 set :copy_exclude, [
   '.git/*',
 ]
+
+namespace :deploy do
+  namespace :email_alert_service do
+    desc "Restart the unpublishing queue consumer"
+    task :restart_unpublishing_queue_consumer do
+      run "sudo initctl restart email-alert-service-unpublishing-queue-consumer-procfile-worker || "\
+          "sudo initctl start email-alert-service-unpublishing-queue-consumer-procfile-worker"
+    end
+  end
+end
+
+after "deploy:restart", "deploy:email_alert_service:restart_unpublishing_queue_consumer"


### PR DESCRIPTION
This will ensure that the unpublishing queue consumer is restarted on deployment,
for clarity and to ensure old processes do not linger.