### PR TITLE
Refresh finder-frontend registries on deploy

### DIFF
--- a/finder-frontend/config/deploy.rb
+++ b/finder-frontend/config/deploy.rb
@@ -12,7 +12,9 @@ set :source_db_config_file, false
 set :db_config_file, false
 
 namespace :deploy do
-  task :cold do
-    puts "There's no cold task for this project, just deploy normally"
+  task :update_registries_cache do
+    run "cd #{current_release}; #{rake} RACK_ENV=#{rack_env} registries:cache_refresh"
   end
 end
+
+after "deploy:finalize_update", "deploy:update_registries_cache"


### PR DESCRIPTION
This will call the registries:cache_refresh rake task to update the shared memcached instance, as part of the deploy.

Merge after https://github.com/alphagov/finder-frontend/pull/1192
https://trello.com/c/uwm4BnOT/787-import-the-new-topic-registry-on-app-deploy-m