### PR TITLE
Initialize finder-frontend cron jobs during deploy

### DIFF
--- a/finder-frontend/config/deploy.rb
+++ b/finder-frontend/config/deploy.rb
@@ -11,6 +11,10 @@ set :rails_env, 'production'
 set :source_db_config_file, false
 set :db_config_file, false
 
+# https://github.com/javan/whenever#capistrano-integration
+require "whenever/capistrano"
+set :whenever_command, "govuk_setenv finder-frontend bundle exec whenever"
+
 namespace :deploy do
   task :cold do
     puts "There's no cold task for this project, just deploy normally"


### PR DESCRIPTION
This uses the whenever gem to start finder-frontend cron jobs.

This should be merged after https://github.com/alphagov/finder-frontend/pull/1195.

https://trello.com/c/knffA0Fb/786-import-the-new-topic-registry-on-a-schedule-s