### PR TITLE
Update Scripts to Automatically Detect AWS Region

### DIFF
--- a/lib/fetch_build.rb
+++ b/lib/fetch_build.rb
@@ -29,7 +29,7 @@ def fetch_to_tempfile(url)
 end
 
 def fetch_from_s3_to_tempfile(bucket, key)
-  s3 = Aws::S3::Client.new(region: 'eu-west-1')
+  s3 = Aws::S3::Client.new(region: ENV['AWS_DEFAULT_REGION'])
   file = Tempfile.new(application.to_s)
   file.binmode
 

--- a/recipes/notify.rb
+++ b/recipes/notify.rb
@@ -150,7 +150,7 @@ namespace :deploy do
     desc "Makes a copy of the deployed artefact in the S3 bucket for future deployments"
     task :copy_artefact do
       if ENV['USE_S3']
-        s3 = Aws::S3::Client.new(region: 'eu-west-1')
+        s3 = Aws::S3::Client.new(region: ENV['AWS_DEFAULT_REGION'])
 
         unless ENV['TAG'] == "deployed-to-#{ENV['ORGANISATION']}"
           source_key = "#{application}/#{ENV['TAG']}/#{application}"


### PR DESCRIPTION
This replaces the hardcoded region. Some apps are failing
in the Training environment as it exists in eu-west-2
(rather than eu-west-1).

solo: @camdesgov