### PR TITLE
Warm finder-frontend cache on deploy

### DIFF
--- a/finder-frontend/config/deploy.rb
+++ b/finder-frontend/config/deploy.rb
@@ -17,7 +17,7 @@ set :whenever_command, "govuk_setenv finder-frontend bundle exec whenever"
 
 namespace :deploy do
   task :update_registries_cache do
-    run "cd #{current_release}; #{rake} RACK_ENV=#{rack_env} registries:cache_refresh"
+    run "cd #{current_release}; #{rake} RACK_ENV=#{rack_env} registries:cache_warm"
   end
 end
 


### PR DESCRIPTION
Previously we'd refresh the registry cache on all the boxes.  I don't think
we need to necessarily do that.  We just need to make sure there is something
already there before the app starts accepting requests.  If we're deploying
a new version of finder-frontend then caches will already be populated.

If we need to refresh all the registries, then we can use fabric scripts
and run the `registries:cache_refresh` rake task as before.

Caches are still refreshed on a schedule defined in finder-frontend.

Don't merge before https://github.com/alphagov/finder-frontend/pull/1437