### PR TITLE
Resolve net-ssh deprecation message

### DIFF
--- a/recipes/defaults.rb
+++ b/recipes/defaults.rb
@@ -13,7 +13,7 @@ set :repo_name,      fetch(:repo_name, application).to_s # XXX: this must appear
 set :repository,     "#{ENV.fetch('GIT_ORIGIN_PREFIX', 'git@github.com:alphagov')}/#{repo_name}"
 
 set :scm,            :git
-set :ssh_options,    { :forward_agent => true, :keys => "#{ENV['HOME']}/.ssh/id_rsa", :verify_host_key => false }
+set :ssh_options,    { :forward_agent => true, :keys => "#{ENV['HOME']}/.ssh/id_rsa", :verify_host_key => :never }
 set :use_sudo,       false
 set :user,           "deploy"
 set :dockerhub_repo, "govuk"

--- a/recipes/docker.rb
+++ b/recipes/docker.rb
@@ -1,6 +1,6 @@
 # Deploy docker applications
 #
-set :ssh_options,    { :forward_agent => true, :keys => "#{ENV['HOME']}/.ssh/id_rsa", :verify_host_key => false }
+set :ssh_options,    { :forward_agent => true, :keys => "#{ENV['HOME']}/.ssh/id_rsa", :verify_host_key => :never }
 set :use_sudo,       false
 set :user,           "deploy"
 set :dockerhub_repo, "govuk"


### PR DESCRIPTION
Resolves the [following warning](https://github.com/net-ssh/net-ssh/blob/2c3450670533b9cda48375b6056f313b02afffcd/lib/net/ssh/transport/session.rb#L313) as seen in [application deployments](https://deploy.blue.staging.govuk.digital/job/Deploy_App/2060/console):

> 14:17:46 verify_host_key: false is deprecated, use :never

(one for each destination machine)

[The PR deprecating the old behaviour](https://github.com/net-ssh/net-ssh/pull/595)