### PR TITLE
Warm content items cache on finder-frontend deploy

### DIFF
--- a/finder-frontend/config/deploy.rb
+++ b/finder-frontend/config/deploy.rb
@@ -19,6 +19,10 @@ namespace :deploy do
   task :update_registries_cache do
     run "cd #{current_release}; #{rake} RACK_ENV=#{rack_env} registries:cache_warm"
   end
+
+  task :update_content_items_cache do
+    run "cd #{current_release}; #{rake} RACK_ENV=#{rack_env} content_store:refresh_cache_soft"
+  end
 end
 
-after "deploy:finalize_update", "deploy:update_registries_cache"
+after "deploy:finalize_update", "deploy:update_registries_cache", "deploy:update_content_items_cache"


### PR DESCRIPTION
Following https://github.com/alphagov/finder-frontend/pull/1558 this will cache content items at deploy time.

Trello: https://trello.com/c/1PG0oqZg/992