### PR TITLE
Generate sitemaps on first search-api deploy

### DIFF
--- a/search-api/config/deploy.rb
+++ b/search-api/config/deploy.rb
@@ -1,5 +1,3 @@
-# rubocop:disable Naming/HeredocDelimiterNaming
-
 set :application, "search-api"
 set :capfile_dir, File.expand_path('../', File.dirname(__FILE__))
 set :server_class, "search"
@@ -19,6 +17,7 @@ set :copy_exclude, [
 ]
 
 namespace :deploy do
+  # rubocop:disable Naming/HeredocDelimiterNaming
   task :create_sitemaps do
     # Preserve the directory containing sitemap files between releases
     run <<-EOT
@@ -45,6 +44,7 @@ namespace :deploy do
       govuk_setenv search-api bundle exec rake sitemap:generate_and_replace
     EOT
   end
+  # rubocop:enable Naming/HeredocDelimiterNaming
 
   task :migrate, :roles => :db, :only => { :primary => true } do
     run "cd #{current_release}; #{rake} RACK_ENV=#{rack_env} RUMMAGER_INDEX=all rummager:migrate_schema rummager:clean"

--- a/search-api/config/deploy.rb
+++ b/search-api/config/deploy.rb
@@ -1,4 +1,4 @@
-# rubocop:disable Metrics/BlockLength, Naming/HeredocDelimiterNaming
+# rubocop:disable Naming/HeredocDelimiterNaming
 
 set :application, "search-api"
 set :capfile_dir, File.expand_path('../', File.dirname(__FILE__))


### PR DESCRIPTION
Requests for sitemaps are routed to an arbitrary search machine, so if
a new one is brought up we need to generate the sitemaps ASAP to avoid
404 errors.  The task takes about 5 minutes to run.

---

[Trello card](https://trello.com/c/KuBZtH1v/1002-generate-sitemaps-when-a-new-search-machine-is-provisioned)