### PR TITLE
Remove on-disk sitemap deploy logic

### DIFF
--- a/search-api/config/deploy.rb
+++ b/search-api/config/deploy.rb
@@ -1,5 +1,3 @@
-# rubocop:disable Metrics/BlockLength, Naming/HeredocDelimiterNaming
-
 set :application, "search-api"
 set :capfile_dir, File.expand_path('../', File.dirname(__FILE__))
 set :server_class, "search"
@@ -19,25 +17,6 @@ set :copy_exclude, [
 ]
 
 namespace :deploy do
-  task :symlink_sitemaps do
-    # Preserve the directory containing sitemap files between releases
-    run <<-EOT
-      rm -rf #{latest_release}/public/sitemaps &&
-      mkdir -p #{shared_path}/system/sitemaps &&
-      ln -s #{shared_path}/system/sitemaps #{latest_release}/public/sitemaps
-    EOT
-
-    # Preserve the generated sitemap.xml symlink from the previous release if present.
-    #
-    # This de-references the symlink to ensure that it's pointing directly into the shared dir.
-    # Otherwise there's a risk of the previous release being cleaned up and this becoming a
-    # dangling symlink
-    run <<-EOT
-      test -L #{previous_release}/public/sitemap.xml || exit 0;
-      ln -s `readlink -nf #{previous_release}/public/sitemap.xml` #{latest_release}/public/sitemap.xml
-    EOT
-  end
-
   task :migrate, :roles => :db, :only => { :primary => true } do
     run "cd #{current_release}; #{rake} RACK_ENV=#{rack_env} RUMMAGER_INDEX=all rummager:migrate_schema rummager:clean"
   end
@@ -63,7 +42,6 @@ namespace :deploy do
   end
 end
 
-after "deploy:finalize_update", "deploy:symlink_sitemaps"
 after "deploy:restart", "deploy:restart_procfile_worker"
 after "deploy:restart", "deploy:restart_publishing_api_listener"
 after "deploy:restart", "deploy:restart_published_content_listener"

--- a/search-api/config/deploy.rb
+++ b/search-api/config/deploy.rb
@@ -5,9 +5,6 @@ set :server_class, "search"
 load 'defaults'
 load 'ruby'
 
-set :whenever_command, "govuk_setenv search-api bundle exec whenever"
-require "whenever/capistrano"
-
 set :source_db_config_file, false
 set :db_config_file, false
 


### PR DESCRIPTION
Sitemaps are stored on and served from s3, so we no longer need to preserve or generate the on-disk ones.

---

[Trello card](https://trello.com/c/KuBZtH1v/1002-generate-sitemaps-when-a-new-search-machine-is-provisioned)