### PR TITLE
pass application name to release app

### DIFF
--- a/licensify-admin/config/deploy.rb
+++ b/licensify-admin/config/deploy.rb
@@ -29,6 +29,7 @@ set :deploy_to, "/data/vhost/#{application}"
 set :repository, "git@github.com:alphagov/licensify"
 set :custom_git_tag, "#{application}-deployed-to-#{ENV['ORGANISATION']}"
 set :branch, ENV["TAG"] ? new_tag : "master"
+set :application_by_name, true
 
 namespace :deploy do
   desc "transfer app from S3 to remote servers."

--- a/licensify-feed/config/deploy.rb
+++ b/licensify-feed/config/deploy.rb
@@ -29,6 +29,7 @@ set :deploy_to, "/data/vhost/#{application}"
 set :repository, "git@github.com:alphagov/licensify"
 set :custom_git_tag, "#{application}-deployed-to-#{ENV['ORGANISATION']}"
 set :branch, ENV["TAG"] ? new_tag : "master"
+set :application_by_name, true
 
 namespace :deploy do
   desc "transfer app from S3 to remote servers."

--- a/recipes/defaults.rb
+++ b/recipes/defaults.rb
@@ -3,20 +3,21 @@ load "notify"
 
 require "slack_announcer"
 
-set :branch,         ENV["TAG"] || "master"
-set :deploy_to,      "/data/apps/#{application}"
-set :deploy_via,     :rsync_with_remote_cache
-set :organisation,   ENV["ORGANISATION"]
-set :keep_releases,  2
-set :rake,           "govuk_setenv #{application} #{fetch(:rake, 'bundle exec rake')}"
-set :repo_name,      fetch(:repo_name, application).to_s # XXX: this must appear before the `require 'defaults' in recipe names
-set :repository,     "#{ENV.fetch('GIT_ORIGIN_PREFIX', 'git@github.com:alphagov')}/#{repo_name}"
+set :branch,              ENV["TAG"] || "master"
+set :deploy_to,           "/data/apps/#{application}"
+set :deploy_via,          :rsync_with_remote_cache
+set :organisation,        ENV["ORGANISATION"]
+set :keep_releases,       2
+set :rake,                "govuk_setenv #{application} #{fetch(:rake, 'bundle exec rake')}"
+set :repo_name,           fetch(:repo_name, application).to_s # XXX: this must appear before the `require 'defaults' in recipe names
+set :repository,          "#{ENV.fetch('GIT_ORIGIN_PREFIX', 'git@github.com:alphagov')}/#{repo_name}"
 
-set :scm,            :git
-set :ssh_options,    { :forward_agent => true, :keys => "#{ENV['HOME']}/.ssh/id_rsa", :verify_host_key => :never }
-set :use_sudo,       false
-set :user,           "deploy"
-set :dockerhub_repo, "govuk"
+set :scm,                 :git
+set :ssh_options,         { :forward_agent => true, :keys => "#{ENV['HOME']}/.ssh/id_rsa", :verify_host_key => :never }
+set :use_sudo,            false
+set :user,                "deploy"
+set :dockerhub_repo,      "govuk"
+set :application_by_name, false
 
 # Always run deploy:setup on every server as it's idempotent
 after "deploy:set_servers", "deploy:setup"

--- a/recipes/notify.rb
+++ b/recipes/notify.rb
@@ -46,6 +46,8 @@ namespace :deploy do
 
             form_data = {
               "repo" => repository,
+              "application_by_name" => application_by_name,
+              "application_name" => application,
               "deployment[environment]" => deployed_to_environment,
               "deployment[jenkins_user_email]" => ENV["BUILD_USER_EMAIL"],
               "deployment[jenkins_user_name]" => ENV["BUILD_USER"],


### PR DESCRIPTION
During the migration of licensify to AWS, govuk-app-deployment will be
used to individually deploy the 3 licensify apps in the single repo:
https://github.com/alphagov/licensify since they are hosted on different
machine classes. This is in contrast with the current method of
deploying licensify where a single deployment across multiple machine
classes is performed using the deprecated alphagov-deployment.

Unfortunately, govuk-app-deployment will not be able to record correctly
the 3 individual app deployments with the release app because the
release app uses the repo name to identify an app and the 3 apps share
the same repo.

Hence, we change the notification to the release app in this PR so that
the application name is also sent to the release app to identify which
app to record the new deployment under.

To maintain backward compability with the previous way of identifying an
app by repo name in the release app, the application name will only be
used by the release app if the additional boolean parameter
`application_by_name` is set to true when the notification is made.

The corresponding changes to the release app is done in
alphagov/release#470