### PR TITLE
SmartAnswers: Reduce the verbosity of the rsync deploy command

### DIFF
--- a/smartanswers/config/deploy.rb
+++ b/smartanswers/config/deploy.rb
@@ -13,7 +13,7 @@ set :db_config_file, false
 set :rails_env, "production"
 set :source_db_config_file, false
 
-set :rsync_options, "-az --delete --exclude '.git/' -v --delete-excluded --exclude 'test/artefacts/'"
+set :rsync_options, "-az --delete --exclude '.git/' --delete-excluded --exclude 'test/artefacts/'"
 
 namespace :deploy do
   task :cold do


### PR DESCRIPTION
- SmartAnswers has a _lot_ of files. This `-v` flag dates back to
  https://github.com/alphagov/govuk-app-deployment/commit/074ca6da726fcee0b51fdb476e2bc408b16899e7.
  I had to scroll for a long time to see the output of the actual deploy
  as opposed to the files the rsync was transferring. This feels
  redundant. If we need it in future, we can add it back?

Example deploy: https://deploy.blue.staging.govuk.digital/job/Deploy_App/2841/console