### PR TITLE
Revert "Smart answer: Exclude regression test artefacts"

### DIFF
--- a/smartanswers/config/deploy.rb
+++ b/smartanswers/config/deploy.rb
@@ -13,8 +13,6 @@ set :db_config_file, false
 set :rails_env, "production"
 set :source_db_config_file, false
 
-set :rsync_options, "-az --delete --exclude '.git/' -v --delete-excluded --exclude 'test/artefacts/'"
-
 namespace :deploy do
   task :cold do
     puts "There's no cold task for this project, just deploy normally"


### PR DESCRIPTION
Reverts alphagov/govuk-app-deployment#164

We [don't have smart-answers regression tests any more](https://github.com/alphagov/smart-answers/pull/3896), so we can revert this commit entirely, not partially like I tried in #336. Thanks for the pointer, @thomasleese.