### PR TITLE
Deploy Mapit using Python 3

### DIFF
--- a/mapit/config/deploy.rb
+++ b/mapit/config/deploy.rb
@@ -3,6 +3,9 @@ set :server_class, "mapit"
 set :capfile_dir, File.expand_path("../", File.dirname(__FILE__))
 set :shared_children, shared_children + %w(log)
 
+set :virtualenv_name, "venv3"
+set :virtualenv_python_binary, "python3"
+
 load "defaults"
 load "python"
 

--- a/recipes/python.rb
+++ b/recipes/python.rb
@@ -5,8 +5,9 @@
 # "requirements.txt" at the root of your repository. For the sake of simplicity,
 # the latter is usually desirable.
 
-set :shared_children, shared_children + %w(venv)
-set :virtualenv_name, "venv"
+set :virtualenv_name, fetch(:virtualenv_name, "venv")
+set :shared_children, shared_children + [virtualenv_name]
+set :virtualenv_python_binary, fetch(:virtualenv_python_binary, "python")
 set(:virtualenv_path) { "#{shared_path}/#{virtualenv_name}" }
 set :sleep_after_server_start, 1
 
@@ -24,7 +25,7 @@ namespace :deploy do
                       else
                         ""
                       end
-    run "test -f '#{virtualenv_path}/bin/python' || virtualenv -q #{setuptools_flag} --no-site-packages '#{virtualenv_path}'"
+    run "test -f '#{virtualenv_path}/bin/python' || virtualenv -p #{virtualenv_python_binary} -q #{setuptools_flag} --no-site-packages '#{virtualenv_path}'"
   end
 
   task :install_deps, :roles => :app do


### PR DESCRIPTION
This makes it possible to customise the version of Python used when creating a virtual environment and then configures Mapit to deploy into a Python 3 virtual environment.

I've changed the directory name of the virtual environment from `venv` to `venv3` because it's not easy to upgrade the version of Python inside a virtual enviroment in place. This way we can leave the old virtual environment working while we switch over in case we have to rollback for whatever reason.

[Trello Card](https://trello.com/c/DzbcRdub/1501-5-deploy-mapit-using-python-3)
