### PR TITLE
fix licensify release notification

### DIFF
--- a/licensify/config/deploy.rb
+++ b/licensify/config/deploy.rb
@@ -29,6 +29,7 @@ set :deploy_to, "/data/vhost/#{application}"
 set :repository, "git@github.com:alphagov/licensify"
 set :custom_git_tag, "#{application}-deployed-to-#{ENV['ORGANISATION']}"
 set :branch, ENV["TAG"] ? new_tag : "master"
+set :application_by_name, true
 
 namespace :deploy do
   desc "transfer app from S3 to remote servers."


### PR DESCRIPTION
Since licensify is identified in release app by application name, the capitrano file must be updated as was done for licensify-admin and licensify-feed in the [commit](https://github.com/alphagov/govuk-app-deployment/commit/db8e78c0330bcfbf46bc8d2a283f08097b1fd624)