### PR TITLE
Stop deploying govuk-content-schemas to backend boxes

### DIFF
--- a/govuk-content-schemas/config/deploy.rb
+++ b/govuk-content-schemas/config/deploy.rb
@@ -1,6 +1,6 @@
 set :application, "govuk-content-schemas"
 set :capfile_dir, File.expand_path("../", File.dirname(__FILE__))
-set :server_class, %w(backend publishing_api)
+set :server_class, "publishing_api"
 
 load "defaults"
 


### PR DESCRIPTION
Trello: https://trello.com/c/zHm2B8VX/1242-present-organisation-political-status-from-whitehall-to-publishing-api

Now that we have backend boxes in Carrenza and publishing-api boxes in
AWS we are hit with a problem that it's very difficult to deploy
govuk-content-schemas. It appears that no apps other than Publishing API
use these schemas outside of a test environment so this is safe to set
to just publishing-api boxes.

I'm understanding the reason this is deployed to both boxes is because
this was at the point in time when Publishing API was transitioned to
it's own machine and briefly needed to be on both machines.