### PR TITLE
Pull latest LTR model before restarting search app

### DIFF
--- a/search-api/config/deploy.rb
+++ b/search-api/config/deploy.rb
@@ -44,6 +44,7 @@ namespace :deploy do
   end
 end
 
+before "deploy:restart", "deploy:pull_latest_ltr_model"
 after "deploy:restart", "deploy:restart_procfile_worker"
 after "deploy:restart", "deploy:restart_publishing_api_listener"
 after "deploy:restart", "deploy:restart_published_content_listener"


### PR DESCRIPTION
This is a followup to https://github.com/alphagov/govuk-app-deployment/pull/343

https://trello.com/c/Azj599Sw/1213-improve-resilience-of-learn-to-rank