### PR TITLE
Revert "Pull latest LTR model before restarting search app"

### DIFF
--- a/search-api/config/deploy.rb
+++ b/search-api/config/deploy.rb
@@ -44,7 +44,6 @@ namespace :deploy do
   end
 end
 
-before "deploy:restart", "deploy:pull_latest_ltr_model"
 after "deploy:restart", "deploy:restart_procfile_worker"
 after "deploy:restart", "deploy:restart_publishing_api_listener"
 after "deploy:restart", "deploy:restart_published_content_listener"


### PR DESCRIPTION
The rake task isn't yet ready, so I'll revert this one.

This reverts commit 121ea76a6239d599c22c31d39f2257284a98260a.