### PR TITLE
Clean up unused gem dependencies

### DIFF
--- a/recipes/defaults.rb
+++ b/recipes/defaults.rb
@@ -7,7 +7,7 @@ set :branch,              ENV["TAG"] || "master"
 set :deploy_to,           "/data/apps/#{application}"
 set :deploy_via,          :rsync_with_remote_cache
 set :organisation,        ENV["ORGANISATION"]
-set :keep_releases,       2
+set :keep_releases,       2 # XXX: The value must be less than or equal to 2, as we only keep dependencies for 2 releases. See `cleanup_old_dependencies`.
 set :rake,                "govuk_setenv #{application} #{fetch(:rake, 'bundle exec rake')}"
 set :repo_name,           fetch(:repo_name, application).to_s # XXX: this must appear before the `require 'defaults' in recipe names
 set :repository,          "#{ENV.fetch('GIT_ORIGIN_PREFIX', 'git@github.com:alphagov')}/#{repo_name}"

--- a/recipes/ruby.rb
+++ b/recipes/ruby.rb
@@ -34,6 +34,11 @@ namespace :deploy do
     restart
   end
 
+  desc "Performs a bundle clean to remove used gems"
+  task :clean_old_dependencies do
+    run "cd #{current_path} && #{bundle_cmd} clean" unless current_path.nil? || current_path.empty?
+  end
+
   task :notify_ruby_version do
     run "cd #{latest_release} && ruby -v"
   end
@@ -79,6 +84,7 @@ namespace :deploy do
   end
 end
 
+before "deploy:update_code", "deploy:clean_old_dependencies"
 after "deploy:update_code", "deploy:notify_ruby_version"
 after "deploy:finalize_update", "deploy:upload_initializers"
 after "deploy:upload_config", "deploy:upload_organisation_config"


### PR DESCRIPTION
This task run bundle clean to remove old bundler dependencies. To prevent removal of dependencies need for rollback version, it is run before deploy on the previous versions Gemfile. This is to prevent the accumulation of old Gem files which can use up disk space on servers.