### PR TITLE
Fix App-Deployment Error with Extra Check

### DIFF
--- a/recipes/ruby.rb
+++ b/recipes/ruby.rb
@@ -36,7 +36,7 @@ namespace :deploy do
 
   desc "Performs a bundle clean to remove used gems"
   task :clean_old_dependencies do
-    run "cd #{current_path} && #{bundle_cmd} clean" unless current_path.nil? || current_path.empty?
+    run "if [ -d #{current_path} ]; then cd #{current_path} && #{bundle_cmd} clean; fi" unless current_path.nil? || current_path.empty?
   end
 
   task :notify_ruby_version do


### PR DESCRIPTION
Add extra check to ensure /data/apps/app_name is actually
an existing symlink before running bundle clean command.