### PR TITLE
Recover for 'bundle clean' when deployment fails

### DIFF
--- a/recipes/ruby.rb
+++ b/recipes/ruby.rb
@@ -36,7 +36,7 @@ namespace :deploy do
 
   desc "Performs a bundle clean to remove used gems"
   task :clean_old_dependencies do
-    run "if [ -d #{current_path} ]; then cd #{current_path} && #{bundle_cmd} clean; fi" unless current_path.nil? || current_path.empty?
+    run "if [ -d #{current_path} ] && #{bundle_cmd} check; then cd #{current_path} && #{bundle_cmd} clean; fi" unless current_path.nil? || current_path.empty?
   end
 
   task :notify_ruby_version do


### PR DESCRIPTION
Previously an issue with Bundler (see below) caused git dependencies to
be deleted when 'bundle clean' is run. While the files are normally
replaced as part of the subsequent 'bundle install', a failed deployment
(before the 'bundle install' step) will lead to an issue where 'bundle
clean' fails next time round. In the longterm we expect to upgrade to a
patched version of Bundler. This adds a short-term fix to ensure we only
attempt 'bundle clean' when the local gems are all there.