### PR TITLE
licence-finder: Remove "deploy:symlink_mailer_config" step

### DIFF
--- a/licencefinder/config/deploy.rb
+++ b/licencefinder/config/deploy.rb
@@ -19,4 +19,4 @@ set :copy_exclude, [
   "public/templates",
 ]
 
-after "deploy:upload_initializers", "deploy:symlink_mailer_config"
+after "deploy:upload_initializers"


### PR DESCRIPTION
- It doesn't seem like Licence Finder sends emails, from a quick search
  of "mailer" in the repo. _Licensify_ does, but via Notify.