### PR TITLE
transition: Remove "deploy:symlink_mailer_config" step

### DIFF
--- a/transition/config/deploy.rb
+++ b/transition/config/deploy.rb
@@ -32,5 +32,4 @@ namespace :deploy do
 end
 
 after "deploy:finalize_update", "deploy:symlink_data_dir"
-after "deploy:upload_initializers", "deploy:symlink_mailer_config"
 after "deploy:restart", "deploy:restart_procfile_worker"


### PR DESCRIPTION
- Transition doesn't send emails any more. It used to send exception emails via SES, but this functionality [was removed in 2014](https://github.com/alphagov/transition/commit/83d63f567201fe0e8fa0660973d2da96ec345340) when we switched to Errbit.