### PR TITLE
imminence: Remove "deploy:symlink_mailer_config" step

### DIFF
--- a/imminence/config/deploy.rb
+++ b/imminence/config/deploy.rb
@@ -18,6 +18,5 @@ set :copy_exclude, [
   "public/templates",
 ]
 
-after "deploy:upload_initializers", "deploy:symlink_mailer_config"
 after "deploy:symlink", "deploy:seed_db"
 after "deploy:restart", "deploy:restart_procfile_worker"


### PR DESCRIPTION
- Imminence doesn't send emails any more. It used to send exception emails via SES, but this functionality [was removed in 2014](https://github.com/alphagov/imminence/pull/98/commits/18178b07ddff4ba4c69b91ef1ede2bdd0bc0d1ce) when we switched to Errbit.