### PR TITLE
Remove incorrect after block

### DIFF
--- a/licencefinder/config/deploy.rb
+++ b/licencefinder/config/deploy.rb
@@ -18,5 +18,3 @@ set :copy_exclude, [
   "public/stylesheets",
   "public/templates",
 ]
-
-after "deploy:upload_initializers"


### PR DESCRIPTION
This was added in https://github.com/alphagov/govuk-app-deployment/pull/354 because we didn't realise both arguments are required (it takes two arguments, the second argument is the task to run after the first argument task has run and it's currently preventing deploys of the application:

```
07:47:53 + exec bundle exec cap deploy:without_migrations
07:47:54 bundler: failed to load command: cap (/var/lib/jenkins/bundles/Deploy_App/ruby/2.6.0/bin/cap)
07:47:54 ArgumentError: please specify either a task name or a block to invoke
```