### PR TITLE
Use the correct node class when deploying to specific nodes.

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,5 +48,6 @@ deploy scripts:
 * `DEPLOY_TO` - the environment being deployed to
 * `DEPLOY_TASK` - the deploy task selected in the Jenkins interface ("deploy", "deploy:setup", etc)
 * `TAG` - the tag/branch entered in the Jenkins interface ("release", "release_1234", "build-1234", etc)
+* `TARGET_MACHINES` - optional, comma-separated list of hosts to deploy to. This is intended for deploying apps onto new machine instances. If a machine doesn't match one of the app's `server_class` then it is ignored.
 * `ORGANISATION` - The vCloud organisation being deployed to
 * `CI_DEPLOY_JENKINS_API_KEY` - API key used to fetch build artefacts from ci.dev.publishing.service.gov.uk.


### PR DESCRIPTION
Fixes deployment of Whitehall when new machine instances come up.

This was broken owing to a bug introduced in #325 when we added support for deploying to specific hosts.

When deploying to a specific instance of `whitehall_frontend`, we would iterate over the two server_classes for Whitehall (`whitehall_backend` and `whitehall_frontend`) and each time around the loop we would run the deployment task on the list of machines specified in TARGET_MACHINES. This resulted in running a deployment of `whitehall_frontend` on the specified machine, followed by a deployment of `whitehall_backend` on the same machine.