### PR TITLE
Remove TARGET_MACHINES in favour of the built-in HOSTFILTER.

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,6 @@ deploy scripts:
 * `DEPLOY_TO` - the environment being deployed to
 * `DEPLOY_TASK` - the deploy task selected in the Jenkins interface ("deploy", "deploy:setup", etc)
 * `TAG` - the tag/branch entered in the Jenkins interface ("release", "release_1234", "build-1234", etc)
-* `TARGET_MACHINES` - optional, comma-separated list of hosts to deploy to. This is intended for deploying apps onto new machine instances. If a machine doesn't match one of the app's `server_class` then it is ignored.
+* `HOSTFILTER` - optional, comma-separated list of hosts to deploy to. We use this when deploying apps onto new machine instances. If a machine doesn't match one of the app's `server_class` then it is ignored. This is a Capistrano 2 feature.
 * `ORGANISATION` - The vCloud organisation being deployed to
 * `CI_DEPLOY_JENKINS_API_KEY` - API key used to fetch build artefacts from ci.dev.publishing.service.gov.uk.

--- a/recipes/set_servers.rb
+++ b/recipes/set_servers.rb
@@ -41,23 +41,12 @@ namespace :deploy do
       # Get list of machines in the node class from Puppetmaster, using the
       # govuk_node_list command.
       begin
-        all_nodes_in_class = %x{govuk_node_list -c "#{c}"}.split
-        if all_nodes_in_class.empty?
+        nodes = %x{govuk_node_list -c "#{c}"}.split
+        if nodes.empty?
           raise CommandError.new("set_servers: no servers with class '#{c}' in this environment!")
         end
       rescue Errno::ENOENT
         raise CommandError.new("set_servers: govuk_node_list is not available!")
-      end
-
-      target_machines = ENV.fetch('TARGET_MACHINES', '')
-      if target_machines == 'all' || target_machines == ''
-        nodes = all_nodes_in_class
-      else
-        specified_nodes = target_machines.split(/\s*,\s*/)
-        # Exclude any machines which aren't in the current node class. This
-        # avoids deploying whitehall-admin to a whitehall_frontend machine, for
-        # example.
-        nodes = (specified_nodes.to_set & all_nodes_in_class.to_set).to_a
       end
 
       nodes.each_with_index do |node, index|


### PR DESCRIPTION
We stopped using TARGET_MACHINES in alphagov/govuk-puppet#10146.