### PR TITLE
Don't overwrite mailer config

### DIFF
--- a/support-api/config/deploy.rb
+++ b/support-api/config/deploy.rb
@@ -11,4 +11,3 @@ set :whenever_command, "bundle exec whenever"
 require "whenever/capistrano"
 
 after "deploy:restart", "deploy:restart_procfile_worker"
-after "deploy:upload_initializers", "deploy:symlink_mailer_config"


### PR DESCRIPTION
support-api now uses GOV.UK Notify, not Amazon SES, so needs to use that config (in its own repo)
