### PR TITLE
Don't overwrite mailer config

### DIFF
--- a/specialist-publisher/config/deploy.rb
+++ b/specialist-publisher/config/deploy.rb
@@ -7,6 +7,4 @@ load "ruby"
 load "deploy/assets"
 load "govuk_admin_template"
 
-after "deploy:upload_initializers", "deploy:symlink_mailer_config"
-
 after "deploy:restart", "deploy:restart_procfile_worker"


### PR DESCRIPTION
specialist-publisher now uses GOV.UK Notify, not Amazon SES, so needs to use that config (in its own repo)
