### PR TITLE
Do not call learn_to_rank:pull_model on search-api deploy

### DIFF
--- a/search-api/config/deploy.rb
+++ b/search-api/config/deploy.rb
@@ -37,14 +37,8 @@ namespace :deploy do
   task :restart_published_content_bulk_reindex_listener do
     run "sudo initctl restart search-api-bulk-reindex-queue-listener-procfile-worker || sudo initctl start search-api-bulk-reindex-queue-listener-procfile-worker"
   end
-
-  desc "Fetch latest learn to rank model"
-  task :pull_latest_ltr_model do
-    run "cd #{current_release}; #{rake} RACK_ENV=#{rack_env} learn_to_rank:pull_model"
-  end
 end
 
-before "deploy:restart", "deploy:pull_latest_ltr_model"
 after "deploy:restart", "deploy:restart_procfile_worker"
 after "deploy:restart", "deploy:restart_publishing_api_listener"
 after "deploy:restart", "deploy:restart_published_content_listener"


### PR DESCRIPTION
We no longer use this model.

---

[Trello card](https://trello.com/c/iT2Mh8u6/1413-remove-dockerised-model-and-code)