### PR TITLE
whitehall: Remove the verbose flag from the assets rsync

### DIFF
--- a/whitehall/config/deploy.rb
+++ b/whitehall/config/deploy.rb
@@ -61,7 +61,7 @@ namespace :deploy do
 
     task :rsync_local_assets, roles => :web, :except => { :no_release => true } do
       find_servers.each do |server|
-        puts run_locally "cd #{strategy.local_cache_path} && rsync -avK ./public/government/ #{user}@#{server}:#{shared_path}/assets/;"
+        puts run_locally "cd #{strategy.local_cache_path} && rsync -aK ./public/government/ #{user}@#{server}:#{shared_path}/assets/;"
       end
     end
   end


### PR DESCRIPTION
- We don't need to see every asset that was synced on every deploy. It
  leads to many lines of rsync output listing every file that syncs:

```
13:55:28 assets/
13:55:28 assets/accordion-arrow-173852ce9b24974d300c84b231cc6a168ab0ac76da2f5d7dac8349dace7963a5.png
13:55:28 assets/admin-ee9cf7742f07b31d41c18ea521aab70353fe4fb1e2f8b3b0f4c2021fa5638476.css
13:55:28 assets/admin-ee9cf7742f07b31d41c18ea521aab70353fe4fb1e2f8b3b0f4c2021fa5638476.css.gz
13:55:28 assets/admin-ef5416f019e25b052b0dfe489db771e9c53054e5b4b3ef600fdbdd9fc849a948.js
13:55:28 assets/admin-ef5416f019e25b052b0dfe489db771e9c53054e5b4b3ef600fdbdd9fc849a948.js.gz
...
```

- Currently we have to scroll a long way to reach the end to see any
  failures that may have occurred _after_ syncing the assets.