### PR TITLE
Remove mailer config for short-url-manager

### DIFF
--- a/short-url-manager/config/deploy.rb
+++ b/short-url-manager/config/deploy.rb
@@ -12,5 +12,4 @@ load "govuk_admin_template"
 set :whenever_command, "bundle exec whenever"
 require "whenever/capistrano"
 
-after "deploy:upload_initializers", "deploy:symlink_mailer_config"
 after "deploy:symlink", "deploy:create_mongoid_indexes"


### PR DESCRIPTION
We're switching this app over to sending emails from Notify rather than SES, so we don't need this configuration anymore.

[Trello Card](https://trello.com/c/6FJKUWIs/1794-3-short-url-manager-use-notify-instead-of-amazon-ses)