### PR TITLE
Restart short-url-manager procfile worker

### DIFF
--- a/short-url-manager/config/deploy.rb
+++ b/short-url-manager/config/deploy.rb
@@ -13,3 +13,4 @@ set :whenever_command, "bundle exec whenever"
 require "whenever/capistrano"
 
 after "deploy:symlink", "deploy:create_mongoid_indexes"
+after "deploy:restart", "deploy:restart_procfile_worker"


### PR DESCRIPTION
Now that short-url-manager has a Sidekiq process, it needs to be restarted after deploying the app.

See https://github.com/alphagov/short-url-manager/pull/459 and https://github.com/alphagov/govuk-puppet/pull/10238 for more information.