### PR TITLE
content-data-admin: Remove "deploy:symlink_mailer_config" step

### DIFF
--- a/content-data-admin/config/deploy.rb
+++ b/content-data-admin/config/deploy.rb
@@ -13,4 +13,3 @@ set :copy_exclude, [
 ]
 
 after "deploy:restart", "deploy:restart_procfile_worker"
-after "deploy:upload_initializers", "deploy:symlink_mailer_config"


### PR DESCRIPTION
- As of https://github.com/alphagov/content-data-admin/pull/754 we send
  emails via GOV.UK Notify rather than our own SES.

https://trello.com/c/eLBTob8z/1795-5-content-data-admin-use-notify-instead-of-amazon-ses