### PR TITLE
Don't overwrite mailer config

### DIFF
--- a/service-manual-publisher/config/deploy.rb
+++ b/service-manual-publisher/config/deploy.rb
@@ -8,5 +8,3 @@ load "defaults"
 load "ruby"
 load "deploy/assets"
 load "govuk_admin_template"
-
-after "deploy:upload_initializers", "deploy:symlink_mailer_config"


### PR DESCRIPTION
service-manual-publisher now uses GOV.UK Notify, not Amazon SES, so needs to use that config (in its own repo)

https://trello.com/c/eraJ8WC2/1821-5-service-manual-publisher-use-notify-instead-of-ses