### PR TITLE
Revert "Warn if set_servers doesn't select any nodes"

### DIFF
--- a/recipes/set_servers.rb
+++ b/recipes/set_servers.rb
@@ -59,8 +59,6 @@ namespace :deploy do
         "#{server.host}#{opts}"
       end
 
-      raise CommandError.new("set_servers: no nodes found!") if nodes_to_deploy.empty?
-
       logger.info "set_servers: deploying to #{c} => #{nodes_to_deploy.join(', ')}"
     end
   end


### PR DESCRIPTION
This was put in as a thing to help people manually running the job,
but it seems to break deploying apps where you can deploy to draft and
live machines (like the router).

This reverts commit aa9d922ad1404171ebafeabb663ec9e9d6a26840.