### PR TITLE
Revert "Don't overwrite mailer config"

### DIFF
--- a/publisher/config/deploy.rb
+++ b/publisher/config/deploy.rb
@@ -33,6 +33,7 @@ namespace :deploy do
 end
 
 after "deploy:update_code", "deploy:create_reports_symlink"
+after "deploy:upload_initializers", "deploy:symlink_mailer_config"
 after "deploy:migrate", "deploy:create_mongoid_indexes"
 after "deploy:migrate", "deploy:seed_db"
 after "deploy:restart", "deploy:restart_procfile_worker"


### PR DESCRIPTION
Reverts alphagov/govuk-app-deployment#377

We've spotted a problem where the reply-to address sent via Notify isn't working correctly, so we have to revert this for now until we decide how best to proceed.