### PR TITLE
Change asset paths for apps using www hosts

### DIFF
--- a/collections/config/deploy.rb
+++ b/collections/config/deploy.rb
@@ -9,7 +9,6 @@ load "defaults"
 load "ruby"
 load "deploy/assets"
 
-set :assets_prefix, "collections"
 set :copy_exclude, [
   ".git/*",
   "public/images",

--- a/frontend/config/deploy.rb
+++ b/frontend/config/deploy.rb
@@ -9,7 +9,6 @@ load "defaults"
 load "ruby"
 load "deploy/assets"
 
-set :assets_prefix, "frontend"
 set :copy_exclude, [
   ".git/*",
   "public/images",

--- a/government-frontend/config/deploy.rb
+++ b/government-frontend/config/deploy.rb
@@ -6,5 +6,4 @@ load "defaults"
 load "ruby"
 load "deploy/assets"
 
-set :assets_prefix, "government-frontend"
 set :rails_env, "production"

--- a/static/config/deploy.rb
+++ b/static/config/deploy.rb
@@ -6,7 +6,6 @@ load "defaults"
 load "ruby"
 load "deploy/assets"
 
-set :assets_prefix, "static"
 set :rails_env, "production"
 set :source_db_config_file, false
 set :db_config_file, false


### PR DESCRIPTION
Trello: https://trello.com/c/oNEtjIVp/99-serve-static-assets-from-www-hostname

These apps have all changed their asset paths in order to have their
assets served from the www host. These now no longer need a definition
as they store their assets within the default assets directory.