### PR TITLE
Use default asset path for frontend apps that use it

### DIFF
--- a/calculators/config/deploy.rb
+++ b/calculators/config/deploy.rb
@@ -6,7 +6,6 @@ load "defaults"
 load "ruby"
 
 load "deploy/assets"
-set :assets_prefix, "calculators"
 
 set :db_config_file, false
 set :rails_env, "production"

--- a/email-alert-frontend/config/deploy.rb
+++ b/email-alert-frontend/config/deploy.rb
@@ -6,7 +6,6 @@ load "defaults"
 load "ruby"
 load "deploy/assets"
 
-set :assets_prefix, "email-alert-frontend"
 set :source_db_config_file, false
 set :db_config_file, false
 

--- a/feedback/config/deploy.rb
+++ b/feedback/config/deploy.rb
@@ -6,7 +6,6 @@ load "defaults"
 load "ruby"
 load "deploy/assets"
 
-set :assets_prefix, "feedback"
 set :rails_env, "production"
 set :source_db_config_file, false
 set :db_config_file, false

--- a/finder-frontend/config/deploy.rb
+++ b/finder-frontend/config/deploy.rb
@@ -6,7 +6,6 @@ load "defaults"
 load "ruby"
 load "deploy/assets"
 
-set :assets_prefix, "finder-frontend"
 set :rails_env, "production"
 set :source_db_config_file, false
 set :db_config_file, false

--- a/info-frontend/config/deploy.rb
+++ b/info-frontend/config/deploy.rb
@@ -6,7 +6,6 @@ load "defaults"
 load "ruby"
 load "deploy/assets"
 
-set :assets_prefix, "info-frontend"
 set :rails_env, "production"
 set :source_db_config_file, false
 set :db_config_file, false

--- a/licencefinder/config/deploy.rb
+++ b/licencefinder/config/deploy.rb
@@ -7,7 +7,6 @@ load "defaults"
 load "ruby"
 load "deploy/assets"
 
-set :assets_prefix, "licencefinder"
 set :rails_env, "production"
 set :bundle_without, %i[development test webkit]
 

--- a/manuals-frontend/config/deploy.rb
+++ b/manuals-frontend/config/deploy.rb
@@ -9,7 +9,6 @@ load "defaults"
 load "ruby"
 load "deploy/assets"
 
-set :assets_prefix, "manuals-frontend"
 set :copy_exclude, [
   ".git/*",
   "public/images",

--- a/service-manual-frontend/config/deploy.rb
+++ b/service-manual-frontend/config/deploy.rb
@@ -6,5 +6,4 @@ load "defaults"
 load "ruby"
 load "deploy/assets"
 
-set :assets_prefix, "service-manual-frontend"
 set :rails_env, "production"

--- a/smartanswers/config/deploy.rb
+++ b/smartanswers/config/deploy.rb
@@ -7,7 +7,6 @@ load "defaults"
 load "ruby"
 load "deploy/assets"
 
-set :assets_prefix, "smartanswers"
 set :bundle_without, %i[development test webkit]
 set :db_config_file, false
 set :rails_env, "production"


### PR DESCRIPTION
Trello: https://trello.com/c/oNEtjIVp/99-serve-static-assets-from-www-hostname

These apps have all been modified to now use the default assets
directory for storing their assets so can have the custom paths removed.