### PR TITLE
Allow Whitehall assets to change location

### DIFF
--- a/whitehall/config/deploy.rb
+++ b/whitehall/config/deploy.rb
@@ -61,7 +61,13 @@ namespace :deploy do
 
     task :rsync_local_assets, roles => :web, :except => { :no_release => true } do
       find_servers.each do |server|
-        puts run_locally "cd #{strategy.local_cache_path} && rsync -aK ./public/government/ #{user}@#{server}:#{shared_path}/assets/;"
+        if File.exist?("#{strategy.local_cache_path}/public/government")
+          puts run_locally "cd #{strategy.local_cache_path} && rsync -aK ./public/government/ #{user}@#{server}:#{shared_path}/assets/;"
+        end
+
+        if File.exist?("#{strategy.local_cache_path}/public/assets")
+          puts run_locally "cd #{strategy.local_cache_path} && rsync -aK ./public/assets/ #{user}@#{server}:#{latest_release}/public/assets/;"
+        end
       end
     end
   end


### PR DESCRIPTION
Trello: https://trello.com/c/oNEtjIVp/99-serve-static-assets-from-www-hostname

I'm aiming (somewhat boldly) to move Whitehall assets from their rather
unconventional location of `government/assets` to `assets/whitehall`,
see https://github.com/alphagov/govuk-puppet/pull/10385/commits/aa87066d4b330a702ab26f5ce03b716f6818cf73

One of the places this is challenging is in our custom deployment
configuration here where we rsync the asset path (since,
unconventionally, we build assets on the jenkins machine for
Whitehall and then sync them to the application servers).

These conditionals here act as a stop gap to allow both asset path
deployments to be able to alternate to allow a migration. Once Whitehall
is switched over to using the new path I can clean this up.