### PR TITLE
Remove whitehall asset prefix

### DIFF
--- a/whitehall/config/deploy.rb
+++ b/whitehall/config/deploy.rb
@@ -60,13 +60,7 @@ namespace :deploy do
 
     task :rsync_local_assets, roles => :web, :except => { :no_release => true } do
       find_servers.each do |server|
-        if File.exist?("#{strategy.local_cache_path}/public/government")
-          puts run_locally "cd #{strategy.local_cache_path} && rsync -aK ./public/government/ #{user}@#{server}:#{shared_path}/assets/;"
-        end
-
-        if File.exist?("#{strategy.local_cache_path}/public/assets")
-          puts run_locally "cd #{strategy.local_cache_path} && rsync -aK ./public/assets/ #{user}@#{server}:#{latest_release}/public/assets/;"
-        end
+        puts run_locally "cd #{strategy.local_cache_path} && rsync -aK ./public/assets/ #{user}@#{server}:#{shared_path}/assets/"
       end
     end
   end

--- a/whitehall/config/deploy.rb
+++ b/whitehall/config/deploy.rb
@@ -1,5 +1,4 @@
 set :application, "whitehall"
-set :assets_prefix, "government"
 set :capfile_dir, File.expand_path("../", File.dirname(__FILE__))
 
 set :run_migrations_by_default, true


### PR DESCRIPTION
Trello: https://trello.com/c/oNEtjIVp/99-serve-static-assets-from-www-hostname

This removes the Whitehall asset prefix of government to reflect that https://github.com/alphagov/whitehall/pull/5685 is now merged and deployed.