### PR TITLE
Always configure cron jobs for Publisher

### DIFF
--- a/publisher/config/deploy.rb
+++ b/publisher/config/deploy.rb
@@ -18,12 +18,8 @@ set :copy_exclude, [
   "public/templates",
 ]
 
-# cronjobs should be disabled in the staging organisation, to prevent it collecting
-# production fact-check emails for example.
-if ENV["ORGANISATION"] == "production" || ENV["ORGANISATION"] == "integration"
-  set :whenever_command, "bundle exec whenever"
-  require "whenever/capistrano"
-end
+set :whenever_command, "bundle exec whenever"
+require "whenever/capistrano"
 
 namespace :deploy do
   desc "Create a symlink from the latest_release path to the /data/uploads directory"


### PR DESCRIPTION
We're no longer concerned about staging reading from the production inbox as staging has its own inbox now. See https://github.com/alphagov/govuk-secrets/pull/983 and https://github.com/alphagov/govuk-puppet/pull/10378.