### PR TITLE
Don't run migrations by default when deploying content-store

### DIFF
--- a/content-store/config/deploy.rb
+++ b/content-store/config/deploy.rb
@@ -2,7 +2,7 @@ set :application, "content-store"
 set :capfile_dir, File.expand_path("../", File.dirname(__FILE__))
 set :server_class, %w[content_store draft_content_store]
 
-set :run_migrations_by_default, true
+set :run_migrations_by_default, false
 
 load "defaults"
 load "ruby"


### PR DESCRIPTION
Follows on from removing migrations from content-store:
https://github.com/alphagov/content-store/pull/745