### PR TITLE
Don't run db migrations for publisher by default

### DIFF
--- a/publisher/config/deploy.rb
+++ b/publisher/config/deploy.rb
@@ -2,7 +2,7 @@ set :application, "publisher"
 set :capfile_dir, File.expand_path("../", File.dirname(__FILE__))
 set :server_class, "backend"
 
-set :run_migrations_by_default, true
+set :run_migrations_by_default, false
 
 load "defaults"
 load "ruby"


### PR DESCRIPTION
This follows on from https://github.com/alphagov/publisher/pull/1308