### PR TITLE
Add GovukAdminTemplate test env

### DIFF
--- a/recipes/govuk_admin_template.rb
+++ b/recipes/govuk_admin_template.rb
@@ -12,6 +12,9 @@ namespace :govuk_admin_template do
       # and most/all apps have been upgraded the style should be changed here.
       environment_style = "preview"
       environment_label = "Integration"
+    when "test"
+      environment_style = "test"
+      environment_label = "Test"
     end
 
     template = ERB.new <<~EOT

--- a/recipes/govuk_admin_template.rb
+++ b/recipes/govuk_admin_template.rb
@@ -15,6 +15,9 @@ namespace :govuk_admin_template do
     when "test"
       environment_style = "test"
       environment_label = "Test"
+    else
+      environment_style = "preview"
+      environment_label = "Preview"
     end
 
     template = ERB.new <<~EOT


### PR DESCRIPTION
This will style applications in the test govuk environment
correctly. It'll also fix bugs where test is expected.
E.g. favicon-<environment_style>.png.

This gets used here to style apps: https://github.com/alphagov/govuk_admin_template/blob/0dfd5cffe8ec6ffa2d29767531f1e64826773b7e/app/views/layouts/govuk_admin_template.html.erb#L2

Currently one sees fun errors, e.g. deploying signon when the `environment_style` (`ENV['ORGANISATION']`) is unset (ie in the new `test` env):

```
ActionView::Template::Error (The asset "govuk_admin_template/favicon-.png" is not present in the asset pipeline.):
    22:     <% if content_for?(:favicon) %>
    23:       <%= yield :favicon %>
    24:     <% else %>
    25:       <%= favicon_link_tag environment_style ?
    26:         "govuk_admin_template/favicon-#{environment_style}.png" : "govuk_admin_template/favicon.png"
    27:       %>
    28:     <% end %>
```