### PR TITLE
Extend default rake task with rubocop linting

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -2,7 +2,12 @@ require "rspec/core/rake_task"
 
 RSpec::Core::RakeTask.new(:spec)
 
-task :default => :spec
+desc "Lint Ruby"
+task :lint do
+  sh "bundle exec rubocop"
+end
+
+task default: %i[spec lint]
 
 desc "Send a test deploy message to #bot-testing to see what it looks like"
 task :test_slack do


### PR DESCRIPTION
[Trello card](https://trello.com/c/5Gob6WUL/147-for-everyone-ensure-that-rubocop-runs-as-part-of-bundle-exec-rake-as-one-of-the-default-tasks)