### PR TITLE
Fix bundle command failure for cleaning

### DIFF
--- a/recipes/ruby.rb
+++ b/recipes/ruby.rb
@@ -6,7 +6,6 @@ set :default_environment, {
   "PATH" => "/usr/lib/rbenv/shims:$PATH",
 }
 
-set :bundle_cmd, "bundle"
 set(:source_db_config_file, "secrets/to_upload/database.yml") unless fetch(:source_db_config_file, false)
 set(:db_config_file, "config/database.yml") unless fetch(:db_config_file, false)
 set(:rack_env,  :production)
@@ -36,7 +35,7 @@ namespace :deploy do
 
   desc "Performs a bundle clean to remove used gems"
   task :clean_old_dependencies do
-    run "if [ -d #{current_path} ] && #{bundle_cmd} check; then cd #{current_path} && #{bundle_cmd} clean; fi" unless current_path.nil? || current_path.empty?
+    run "if [ -d #{current_path} ]; then cd #{current_path} && bundle check && bundle clean; fi" unless current_path.nil? || current_path.empty?
   end
 
   task :notify_ruby_version do


### PR DESCRIPTION
This fixes a lasting error where the 'bundle check' command
was run outside of the 'current' directory for the app, which
has no associated rbenv version.

Error:

11:25:56   * executing "if [ -d /data/apps/smartanswers/current ] && bundle check; then cd /data/apps/smartanswers/current && bundle clean; fi"

...

11:25:56 *** [err :: ip-10-13-6-101.eu-west-1.compute.internal] rbenv: bundle: command not found