### PR TITLE
Remove symlink_mailer_config task

### DIFF
--- a/recipes/ruby.rb
+++ b/recipes/ruby.rb
@@ -70,10 +70,6 @@ namespace :deploy do
     end
   end
 
-  task :symlink_mailer_config do
-    run "ln -sf /etc/govuk/actionmailer_ses_smtp_config.rb #{release_path}/config/initializers/mailer.rb"
-  end
-
   task :create_mongoid_indexes, :only => { :primary => true } do
     run "cd #{current_release}; #{rake} db:mongoid:create_indexes"
   end


### PR DESCRIPTION
Once signon is migrated to Notify in alphagov/signon#1476 and #402, this task will no longer be used and can be safely removed.