### PR TITLE
travel-advice-publisher: Don't run migrations by default on deploys

### DIFF
--- a/travel-advice-publisher/config/deploy.rb
+++ b/travel-advice-publisher/config/deploy.rb
@@ -2,7 +2,7 @@ set :application, "travel-advice-publisher"
 set :capfile_dir, File.expand_path("../", File.dirname(__FILE__))
 set :server_class, "backend"
 
-set :run_migrations_by_default, true
+set :run_migrations_by_default, false
 
 load "defaults"
 load "ruby"


### PR DESCRIPTION
- As of https://github.com/alphagov/travel-advice-publisher/commit/a21c6a2b156030af583b0b5e4d38ac70cc52dfd2, there are no migrations to run.
