### PR TITLE
Use govuk_unicorn_reload

### DIFF
--- a/email-alert-service/config/deploy.rb
+++ b/email-alert-service/config/deploy.rb
@@ -1,6 +1,7 @@
 set :application, "email-alert-service"
 set :capfile_dir, File.expand_path("../", File.dirname(__FILE__))
 set :server_class, "email_alert_api"
+set :perform_hard_restart, true
 
 load "defaults"
 load "ruby"

--- a/recipes/ruby.rb
+++ b/recipes/ruby.rb
@@ -15,7 +15,7 @@ set(:rake, "govuk_setenv #{fetch(:application)} #{fetch(:rake, 'bundle exec rake
 namespace :deploy do
   task :start do; end
   task :stop do; end
-  task :restart, :roles => :app, :max_hosts => 1, :except => { :no_release => true } do
+  task :restart, :roles => :app, :except => { :no_release => true } do
     # The deploy user always has permission to run initctl commands.
     if fetch(:perform_hard_restart, false)
       # hard-restart is a non-graceful restart of the app.  This has the advantage
@@ -23,7 +23,7 @@ namespace :deploy do
       # scripts
       run "sudo initctl start #{application} 2>/dev/null || sudo initctl restart #{application}"
     else
-      run "sudo initctl start #{application} 2>/dev/null || sudo initctl reload #{application}"
+      run "sudo initctl start #{application} 2>/dev/null || sudo govuk_unicorn_reload #{application}"
     end
   end
 

--- a/whitehall/config/deploy.rb
+++ b/whitehall/config/deploy.rb
@@ -87,7 +87,7 @@ namespace :deploy do
     if fetch(:perform_hard_restart, false)
       run "sudo initctl start whitehall 2>/dev/null || sudo initctl restart whitehall"
     else
-      run "sudo initctl start whitehall 2>/dev/null || sudo initctl reload whitehall"
+      run "sudo initctl start whitehall 2>/dev/null || sudo govuk_unicorn_reload whitehall"
     end
   end
 
@@ -95,7 +95,7 @@ namespace :deploy do
     if fetch(:perform_hard_restart, false)
       run "sudo initctl start whitehall 2>/dev/null || sudo initctl restart whitehall"
     else
-      run "sudo initctl start whitehall 2>/dev/null || sudo initctl reload whitehall"
+      run "sudo initctl start whitehall 2>/dev/null || sudo govuk_unicorn_reload whitehall"
     end
   end
 


### PR DESCRIPTION
Trello: https://trello.com/c/oPNhsGl3/536-investigate-delaying-an-app-deployment-until-the-app-has-restarted-to-avoid-false-smokey-builds

This is a companion PR for https://github.com/alphagov/govuk-puppet/pull/10761 and I've marked it as a draft while that is under review.

govuk_unicorn_reload is a wrapper script for the command to reload the
unicorn-herder process. This resolves a problem we currently have where
after `initctl reload $app` is run we don't know which version of the
app will be used in any smoke tests as both are running.
govuk_unicorn_reload monitors the switching of these processes and
terminates once it is complete.

This also removes the constraint of running this command only on a
single host at a time as this delays deploys somewhat by multiplying the
wait sequentially. This does provide a slightly higher risk that a bad
deploy could break all versions of the app, but that is basically the
situation already.