### PR TITLE
Remove frontend procfile worker

### DIFF
--- a/frontend/config/deploy.rb
+++ b/frontend/config/deploy.rb
@@ -16,5 +16,3 @@ set :copy_exclude, [
   "public/stylesheets",
   "public/templates",
 ]
-
-after "deploy:restart", "deploy:restart_procfile_worker"


### PR DESCRIPTION
It was removed in https://github.com/alphagov/frontend/commit/b0351b8df69bb1ac5c60f415812353f7a305dc98 and prevents deploys.