### PR TITLE
Fix clean check failing if bundler does exist

### DIFF
--- a/recipes/ruby.rb
+++ b/recipes/ruby.rb
@@ -35,7 +35,12 @@ namespace :deploy do
 
   desc "Performs a bundle clean to remove used gems"
   task :clean_old_dependencies do
-    run "if [ -d #{current_path} ]; then cd #{current_path} && bundle check && bundle clean; fi" unless current_path.nil? || current_path.empty?
+    command = "if [ -d #{current_path} ]; then "\
+                "cd #{current_path}; "\
+                "if bundle check; then bundle clean; fi "\
+              "fi"
+
+    run(command) unless current_path.nil? || current_path.empty?
   end
 
   task :notify_ruby_version do


### PR DESCRIPTION
Previously we modified the clean command to cope with the "current"
directory not existing [1]. However, this recreated a different problem
where the command fails if the directory exists, but bundler is not
installed. This reformats the command and fixes it to cope with both
scenarios.

[1]: https://github.com/alphagov/govuk-app-deployment/commit/87caf8ecf5246121dacaf6b69258de4339cf14cd#diff-97fa2c042e78c4b0f5844fec2cbf2a3cb66618cbf5e4031aae93eb9d0346dc6cR38