### PR TITLE
Revert "Add unpublishing queue consumer restart script"

### DIFF
--- a/email-alert-service/config/deploy.rb
+++ b/email-alert-service/config/deploy.rb
@@ -9,15 +9,3 @@ load "ruby"
 set :copy_exclude, [
   ".git/*",
 ]
-
-namespace :deploy do
-  namespace :email_alert_service do
-    desc "Restart the unpublishing queue consumer"
-    task :restart_unpublishing_queue_consumer do
-      run "sudo initctl restart email-alert-service-unpublishing-queue-consumer-procfile-worker || "\
-          "sudo initctl start email-alert-service-unpublishing-queue-consumer-procfile-worker"
-    end
-  end
-end
-
-after "deploy:restart", "deploy:email_alert_service:restart_unpublishing_queue_consumer"


### PR DESCRIPTION
https://trello.com/c/fbmVmwG3/666-remove-the-undocumented-taxon-unpublish-redirect-feature

This reverts commit 0c819699db1bf7a1e0c8a0f3e6813ced234983cb. Note
that the app no longer has an unpublishing worker [1].

[1]: https://github.com/alphagov/email-alert-service/pull/430