### PR TITLE
Update Mapit to use Python 3.6.12

### DIFF
--- a/mapit/config/deploy.rb
+++ b/mapit/config/deploy.rb
@@ -4,7 +4,7 @@ set :capfile_dir, File.expand_path("../", File.dirname(__FILE__))
 set :shared_children, shared_children + %w[log]
 
 set :virtualenv_name, "venv3"
-set :virtualenv_python_binary, "python3.5"
+set :virtualenv_python_binary, "python3.6"
 
 load "defaults"
 load "python"


### PR DESCRIPTION
We have updated Mapit to use Python 3.6.12 in https://github.com/alphagov/govuk-puppet/pull/10947 and https://github.com/alphagov/govuk-puppet/commit/64fe47f435a049ac348a9ec6b296b29baa5cbe55#diff-c4a319376e182c98cdaf96574876b36ea7a793955d0fdc2499bcb72340def948R17, so we also need to update the deployment.

Trello card: https://trello.com/c/rm2WTeqk