### PR TITLE
Remove deprecated command for Mapit

### DIFF
--- a/mapit/config/deploy.rb
+++ b/mapit/config/deploy.rb
@@ -17,7 +17,7 @@ namespace :deploy do
   task :install_deps, :roles => :app do
     # Override task from python recipe, which appends '-e .' to requirements.txt
     # However, '.' only works if `pip` is run from `release_path`, which its not
-    run "'#{virtualenv_path}/bin/pip' install --download-cache '#{shared_path}/download-cache' --exists-action=w -r '#{release_path}/requirements.txt'"
+    run "'#{virtualenv_path}/bin/pip' install --exists-action=w -r '#{release_path}/requirements.txt'"
   end
 
   task :upload_configuration do


### PR DESCRIPTION
`--download-cache` was deprecated in pip 6 and removed in pip 8.
We are now using pip 18.1 (previously pip 1.5.4) so this command
is no longer available.

See https://github.com/pypa/pip/blob/3861c4b8fbceb0d97ce312dab83a5649139692de/NEWS.rst#60-2014-12-22
and https://pip.pypa.io/en/stable/reference/pip_install/#caching
for more information.

Trello card: https://trello.com/c/rm2WTeqk