### PR TITLE
Use govuk_supervised_initctl script for Ruby deploys

### DIFF
--- a/recipes/ruby.rb
+++ b/recipes/ruby.rb
@@ -21,9 +21,9 @@ namespace :deploy do
       # hard-restart is a non-graceful restart of the app.  This has the advantage
       # of being immediate, and blocking.  Used by some of the post data-syncing
       # scripts
-      run "sudo initctl start #{application} 2>/dev/null || sudo initctl restart #{application}"
+      run "sudo govuk_supervised_initctl start #{application} || sudo govuk_supervised_initctl restart #{application}"
     else
-      run "sudo initctl start #{application} 2>/dev/null || sudo govuk_unicorn_reload #{application}"
+      run "sudo govuk_supervised_initctl start #{application} || sudo govuk_supervised_initctl reload #{application}"
     end
   end
 


### PR DESCRIPTION
This will check that starting, restarting or reloading the apps actually
result in running processes before being considered successful. It
resolves situations where a deployment appears successful but actually
the app never started.

This script supersedes the govuk_unicorn_reload script which will soon
be removed from govuk-puppet.