### PR TITLE
Set real_revision to the deployed branch

### DIFF
--- a/recipes/defaults.rb
+++ b/recipes/defaults.rb
@@ -19,6 +19,10 @@ set :user,                "deploy"
 set :dockerhub_repo,      "govuk"
 set :application_by_name, false
 
+# This changes what is written to the REVISION file from the Git SHA to a more
+# human-readable string.
+set :real_revision,       fetch(:branch)
+
 # Always run deploy:setup on every server as it's idempotent
 after "deploy:set_servers", "deploy:setup"
 


### PR DESCRIPTION
The real_revision configuration variable is used internally by Capistrano by write out the REVISION file when deploying an app:

- https://github.com/capistrano/capistrano/blob/08a82f3618425eae7539e2bbd34a87e35bac2800/lib/capistrano/recipes/deploy/strategy/remote.rb#L43-L47
- https://github.com/capistrano/capistrano/blob/08a82f3618425eae7539e2bbd34a87e35bac2800/lib/capistrano/recipes/deploy/strategy/base.rb#L83-L87

By setting the configuration variable manually ourselves, we change it from the default (a Git SHA of the tag) to a more human-readable string.

This value is currently used by Sentry to display the release of the app, and using the Git SHA makes it harder to quickly see at a glance the release of the app:

- https://github.com/getsentry/sentry-ruby/blob/ace176cfceaefc91e29364a1c4180a67337e8ab0/sentry-raven/lib/raven/configuration.rb#L481-L494

By changing this value, Capistrano will also use this when performing other Git related commands, however this shouldn't be a problem as anywhere that Git accepts the SHA, it should accept the name of the branch or tag.

An alternative to this could be to add our own deploy task which overwrites the `REVISION` file as written by Capistrano, but I thought that would be more confusing as it's changing the built in behaviour of Capistrano.

[Trello Card](https://trello.com/c/Tv6zcDQD/2490-investigate-fix-the-release-reported-in-sentry-timebox-2-days)