### PR TITLE
Write revision file with human readable string

### DIFF
--- a/recipes/defaults.rb
+++ b/recipes/defaults.rb
@@ -19,10 +19,6 @@ set :user,                "deploy"
 set :dockerhub_repo,      "govuk"
 set :application_by_name, false
 
-# This changes what is written to the REVISION file from the Git SHA to a more
-# human-readable string.
-set :real_revision,       fetch(:branch)
-
 # Always run deploy:setup on every server as it's idempotent
 after "deploy:set_servers", "deploy:setup"
 

--- a/recipes/defaults.rb
+++ b/recipes/defaults.rb
@@ -98,10 +98,17 @@ namespace :deploy do
       put(database_yaml, File.join(release_path, db_config_file))
     end
   end
+
+  task :write_revision_file do
+    # We're overwriting the default Capistrano behaviour of writing a SHA to get a more
+    # human-readable string in this file.
+    put ENV["TAG"], File.join(release_path, "REVISION")
+  end
 end
 
 after "deploy:finalize_update", "deploy:upload_config"
 after "deploy:restart", "deploy:cleanup"
+after "deploy:update_code", "deploy:write_revision_file"
 
 namespace :deploy do
   namespace :email do


### PR DESCRIPTION
By default Capistrano writes out the Git SHA of the release deployed to this file, but we'd prefer it to be a more human readable string. By changing it to the `TAG` that was deployed this should be the case.

Specifically, this helps us navigate issues in Sentry as the more human readable string will be used to associate issues with the release it was introduced in, allowing us to better correlate problems with a release.

This was attempted before in dd7f387 but it caused issue with branch deploys.