### PR TITLE
Send slack message on deployment failures

### DIFF
--- a/recipes/defaults.rb
+++ b/recipes/defaults.rb
@@ -25,6 +25,8 @@ after "deploy:set_servers", "deploy:setup"
 namespace :deploy do
   task :default do
     transaction do
+      on_rollback { find_and_execute_task("deploy:notify:slack_message_failed") }
+
       update_code
     end
     if fetch(:run_migrations_by_default, false)

--- a/recipes/notify.rb
+++ b/recipes/notify.rb
@@ -84,6 +84,17 @@ namespace :deploy do
       end
     end
 
+    desc "Announce on Slack that the deploy has failed"
+    task :slack_message_failed do
+      if ENV["SLACK_NOTIFICATIONS"] == "true"
+        annoucer = SlackAnnouncer.new(ENV["ORGANISATION"], ENV["BADGER_SLACK_WEBHOOK_URL"])
+        annoucer.announce_failed(repo_name, application)
+        if ENV["ORGANISATION"] == "production"
+          annoucer.announce_failed(repo_name, application, "#govuk-2ndline")
+        end
+      end
+    end
+
     desc "Record the deployment as a Graphite event"
     task :graphite_event do
       require "json"


### PR DESCRIPTION
Currently the #app-deployment channel is alerted when a deployment starts or completes, but failures are silent.
This change adds a failure message to the channel, and for Production deploys also alerts #govuk-2ndline for greater visibility.


When any Capistrano task within a transaction fails it will be rolled-back. `on_rollback` will execute the specified task
https://github.com/capistrano/capistrano-2.x-docs/blob/master/2.x-DSL-Configuration-Execution-On-Rollback.md

Our deploys may fail for other reasons outside of this transaction. Capistrano 3.1.x introduced a 'deploy:failed' callback which is invoked on any namespaced task failure independent of transactions, but we are currently tied to 2.13.5

This has been tested with a deliberately broken app deployment, and attempting to deploy a non-existent branch, and has created the expected message.

<img width="832" alt="Screenshot 2021-05-19 at 17 22 14" src="https://user-images.githubusercontent.com/13475227/118848713-e7631d80-b8c6-11eb-917a-2daadea48f07.png">

<img width="693" alt="Screenshot 2021-05-19 at 17 22 25" src="https://user-images.githubusercontent.com/13475227/118848743-ed58fe80-b8c6-11eb-9b36-7af04aa90d3c.png">

[trello](https://trello.com/c/bO8mQkIf/2512-3-set-up-an-alert-for-failed-production-deploys)
