### PR TITLE
add ability to toggle `--no-site-packages` option for virtualenv

### DIFF
--- a/mapit/config/deploy.rb
+++ b/mapit/config/deploy.rb
@@ -5,6 +5,7 @@ set :shared_children, shared_children + %w[log]
 
 set :virtualenv_name, "venv3"
 set :virtualenv_python_binary, "python3.6"
+set :virtualenv_no_site_package, false
 
 load "defaults"
 load "python"

--- a/recipes/python.rb
+++ b/recipes/python.rb
@@ -38,7 +38,13 @@ namespace :deploy do
                       else
                         ""
                       end
-    run "test -f '#{virtualenv_path}/bin/python' || virtualenv -p #{virtualenv_python_binary} -q #{setuptools_flag} --no-site-packages '#{virtualenv_path}'"
+
+    no_site_packages_option = if fetch(:virtualenv_no_site_package, true)
+                                "--no-site-packages"
+                              else
+                                ""
+                              end
+    run "test -f '#{virtualenv_path}/bin/python' || virtualenv -p #{virtualenv_python_binary} -q #{setuptools_flag} #{no_site_packages_option} '#{virtualenv_path}'"
   end
 
   task :install_deps, :roles => :app do


### PR DESCRIPTION
newer version of virtualenv installed by python3 does not support `--no-site-packages ` option. Therefore, we need the ability to remove that option.

This is needed by mapit.

Tested by successful install with this PR: https://deploy.integration.publishing.service.gov.uk/job/Deploy_App/41505/console