### PR TITLE
run puppet after mapit deployment

### DIFF
--- a/mapit/config/deploy.rb
+++ b/mapit/config/deploy.rb
@@ -36,4 +36,4 @@ namespace :deploy do
 end
 
 before "deploy:finalize_update", "deploy:upload_configuration"
-after "deploy:notify", "deploy:notify:run_puppet",
+after "deploy:notify", "deploy:notify:run_puppet"

--- a/mapit/config/deploy.rb
+++ b/mapit/config/deploy.rb
@@ -36,7 +36,7 @@ namespace :deploy do
 
   desc "Run puppet after app deploy"
   task :run_puppet do
-    run "sudo govuk_puppet --test"
+    run "govuk_puppet --test"
   end
 end
 

--- a/mapit/config/deploy.rb
+++ b/mapit/config/deploy.rb
@@ -33,7 +33,12 @@ namespace :deploy do
   def run_django_command(command)
     run "cd #{release_path} && govuk_setenv #{application} #{virtualenv_path}/bin/python manage.py #{command} --settings=project.settings"
   end
+
+  desc "Run puppet after app deploy"
+  task :run_puppet do
+    run "sudo govuk_puppet --test"
+  end
 end
 
 before "deploy:finalize_update", "deploy:upload_configuration"
-after "deploy:notify", "deploy:notify:run_puppet"
+before "deploy:notify", "deploy:run_puppet"

--- a/mapit/config/deploy.rb
+++ b/mapit/config/deploy.rb
@@ -36,3 +36,4 @@ namespace :deploy do
 end
 
 before "deploy:finalize_update", "deploy:upload_configuration"
+after "deploy:notify", "deploy:notify:run_puppet",

--- a/recipes/notify.rb
+++ b/recipes/notify.rb
@@ -182,7 +182,7 @@ namespace :deploy do
 
     desc "Run puppet after app deploy"
     task :run_puppet do
-      run "govuk_puppet --test"
+      run "sudo govuk_puppet --test"
     end
   end
 end

--- a/recipes/notify.rb
+++ b/recipes/notify.rb
@@ -182,7 +182,7 @@ namespace :deploy do
 
     desc "Run puppet after app deploy"
     task :run_puppet do
-      run "govuk_puppet --test || true"
+      run "govuk_puppet --test"
     end
   end
 end

--- a/recipes/notify.rb
+++ b/recipes/notify.rb
@@ -179,5 +179,10 @@ namespace :deploy do
         end
       end
     end
+
+    desc "Run puppet after app deploy"
+    task :run_puppet do
+      run "govuk_puppet --test || true"
+    end
   end
 end

--- a/recipes/notify.rb
+++ b/recipes/notify.rb
@@ -179,10 +179,5 @@ namespace :deploy do
         end
       end
     end
-
-    desc "Run puppet after app deploy"
-    task :run_puppet do
-      run "sudo govuk_puppet --test"
-    end
   end
 end


### PR DESCRIPTION
We need to run puppet after mapit deployment on a new instance so that mapit data is loaded: https://github.com/alphagov/govuk-puppet/blob/32c1bbbb10067078c1406170666a135b4a10aaea/modules/govuk/manifests/apps/mapit.pp#L120