### PR TITLE
Fix publisher reports permissions at deploy time

### DIFF
--- a/publisher/config/deploy.rb
+++ b/publisher/config/deploy.rb
@@ -26,9 +26,14 @@ namespace :deploy do
   task :create_reports_symlink do
     run "rm -rf #{latest_release}/reports && ln -s /data/uploads/publisher/reports #{latest_release}/reports"
   end
+
+  task :fix_reports_permssions do
+    run "chown deploy:deploy /data/uploads/publisher/reports"
+  end
 end
 
 after "deploy:update_code", "deploy:create_reports_symlink"
+after "deploy:update_code", "deploy:fix_reports_permssions"
 after "deploy:migrate", "deploy:create_mongoid_indexes"
 after "deploy:migrate", "deploy:seed_db"
 after "deploy:restart", "deploy:restart_procfile_worker"


### PR DESCRIPTION
The reports for publisher are run by a user that does not have write access to the output directory, and it seems only to work for reports where there's an existing report file owned by the right user. This corrects that.

https://trello.com/c/fhtbsEgu/2528-create-a-mainstream-url-report-which-shows-all-urls
