### PR TITLE
Revert "Revert "Add unpublishing queue consumer restart script""

### DIFF
--- a/email-alert-service/config/deploy.rb
+++ b/email-alert-service/config/deploy.rb
@@ -9,3 +9,15 @@ load "ruby"
 set :copy_exclude, [
   ".git/*",
 ]
+
+namespace :deploy do
+  namespace :email_alert_service do
+    desc "Restart the unpublishing queue consumer"
+    task :restart_unpublishing_queue_consumer do
+      run "sudo initctl restart email-alert-service-unpublishing-queue-consumer-procfile-worker || "\
+          "sudo initctl start email-alert-service-unpublishing-queue-consumer-procfile-worker"
+    end
+  end
+end
+
+after "deploy:restart", "deploy:email_alert_service:restart_unpublishing_queue_consumer"


### PR DESCRIPTION
[Trello](https://trello.com/c/mQNmwCo2/1140-send-users-an-email-when-a-single-page-is-unpublished)

We've brought this back as part of the single page notifications work.
See this ADR for details:
https://github.com/alphagov/email-alert-api/blob/main/docs/adr/adr-010-send-unpublish-emails-for-single-pages.md

Reverts alphagov/govuk-app-deployment#414