### PR TITLE
Update references to `master` to `main`

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,8 +36,8 @@ set :copy_exclude, [
 
 ## How deployments work
 
-The master `jenkins.sh` script is run by
-[Jenkins](https://github.com/alphagov/govuk-puppet/blob/master/modules/govuk_jenkins/templates/jobs/deploy_app.yaml.erb)
+The main `jenkins.sh` script is run by
+[Jenkins](https://github.com/alphagov/govuk-puppet/blob/main/modules/govuk_jenkins/templates/jobs/deploy_app.yaml.erb)
 to deploy each app.
 
 ## Environment variables available to deploy scripts

--- a/govuk_crawler_worker/config/deploy.rb
+++ b/govuk_crawler_worker/config/deploy.rb
@@ -29,7 +29,7 @@ namespace :deploy do
       file = fetch_from_s3_to_tempfile(bucket, key)
       logger.info "Fetching s3://#{bucket}/#{key}"
     else
-      ci_base_url = "https://ci_alphagov:#{ENV['CI_DEPLOY_JENKINS_API_KEY']}@ci.integration.publishing.service.gov.uk/job/#{application}/job/master"
+      ci_base_url = "https://ci_alphagov:#{ENV['CI_DEPLOY_JENKINS_API_KEY']}@ci.integration.publishing.service.gov.uk/job/#{application}/job/main"
       filename = application.to_s
 
       artefact_to_deploy = fetch(:artefact_number, fetch_last_build_number(ci_base_url))

--- a/licensify-admin/config/deploy.rb
+++ b/licensify-admin/config/deploy.rb
@@ -28,7 +28,7 @@ load "defaults"
 set :deploy_to, "/data/vhost/#{application}"
 set :repository, "git@github.com:alphagov/licensify"
 set :custom_git_tag, "#{application}-deployed-to-#{ENV['ORGANISATION']}"
-set :branch, ENV["TAG"] ? new_tag : "master"
+set :branch, ENV["TAG"] ? new_tag : "main"
 set :application_by_name, true
 
 namespace :deploy do

--- a/licensify-feed/config/deploy.rb
+++ b/licensify-feed/config/deploy.rb
@@ -28,7 +28,7 @@ load "defaults"
 set :deploy_to, "/data/vhost/#{application}"
 set :repository, "git@github.com:alphagov/licensify"
 set :custom_git_tag, "#{application}-deployed-to-#{ENV['ORGANISATION']}"
-set :branch, ENV["TAG"] ? new_tag : "master"
+set :branch, ENV["TAG"] ? new_tag : "main"
 set :application_by_name, true
 
 namespace :deploy do

--- a/licensify/config/deploy.rb
+++ b/licensify/config/deploy.rb
@@ -28,7 +28,7 @@ load "defaults"
 set :deploy_to, "/data/vhost/#{application}"
 set :repository, "git@github.com:alphagov/licensify"
 set :custom_git_tag, "#{application}-deployed-to-#{ENV['ORGANISATION']}"
-set :branch, ENV["TAG"] ? new_tag : "master"
+set :branch, ENV["TAG"] ? new_tag : "main"
 set :application_by_name, true
 
 namespace :deploy do

--- a/recipes/defaults.rb
+++ b/recipes/defaults.rb
@@ -3,7 +3,7 @@ load "notify"
 
 require "slack_announcer"
 
-set :branch,              ENV["TAG"] || "master"
+set :branch,              ENV["TAG"] || "main"
 set :deploy_to,           "/data/apps/#{application}"
 set :deploy_via,          :rsync_with_remote_cache
 set :organisation,        ENV["ORGANISATION"]

--- a/router/config/deploy.rb
+++ b/router/config/deploy.rb
@@ -30,7 +30,7 @@ namespace :deploy do
       file = fetch_from_s3_to_tempfile(bucket, key)
       logger.info "Fetching s3://#{bucket}/#{key}"
     else
-      ci_base_url = "https://ci_alphagov:#{ENV['CI_DEPLOY_JENKINS_API_KEY']}@ci.integration.publishing.service.gov.uk/job/#{application}/job/master"
+      ci_base_url = "https://ci_alphagov:#{ENV['CI_DEPLOY_JENKINS_API_KEY']}@ci.integration.publishing.service.gov.uk/job/#{application}/job/main"
       filename = application.to_s
 
       artefact_to_deploy = fetch(:artefact_number, fetch_last_build_number(ci_base_url))

--- a/spec/docker_tag_pusher_spec.rb
+++ b/spec/docker_tag_pusher_spec.rb
@@ -51,7 +51,7 @@ RSpec.describe DockerTagPusher do
 
           stub_request(
             :get,
-            "https://registry-1.docker.io/v2/govuk/publishing-api/manifests/master",
+            "https://registry-1.docker.io/v2/govuk/publishing-api/manifests/main",
           ).with(headers: {
             "Authorization" => "Bearer bazqux",
             "Accept" => "application/vnd.docker.distribution.manifest.v2+json",
@@ -59,7 +59,7 @@ RSpec.describe DockerTagPusher do
             "Content-Type" => "application/vnd.docker.distribution.manifest.v2+json",
           })
 
-          expect(instance.get_manifest("govuk/publishing-api", "master")).to eq(json)
+          expect(instance.get_manifest("govuk/publishing-api", "main")).to eq(json)
         end
       end
 
@@ -67,13 +67,13 @@ RSpec.describe DockerTagPusher do
         it "raises an error" do
           stub_request(
             :get,
-            "https://registry-1.docker.io/v2/govuk/publishing-api/manifests/master",
+            "https://registry-1.docker.io/v2/govuk/publishing-api/manifests/main",
           ).with(headers: {
             "Authorization" => "Bearer bazqux",
             "Accept" => "application/vnd.docker.distribution.manifest.v2+json",
           }).to_return(status: 404)
 
-          expect { instance.get_manifest("govuk/publishing-api", "master") }.to raise_error("Image or tag not found")
+          expect { instance.get_manifest("govuk/publishing-api", "main") }.to raise_error("Image or tag not found")
         end
       end
 
@@ -81,13 +81,13 @@ RSpec.describe DockerTagPusher do
         it "raises an error" do
           stub_request(
             :get,
-            "https://registry-1.docker.io/v2/govuk/publishing-api/manifests/master",
+            "https://registry-1.docker.io/v2/govuk/publishing-api/manifests/main",
           ).with(headers: {
             "Authorization" => "Bearer bazqux",
             "Accept" => "application/vnd.docker.distribution.manifest.v2+json",
           }).to_return(status: 401)
 
-          expect { instance.get_manifest("govuk/publishing-api", "master") }.to raise_error(/Error \(401\) while fetching manifest/)
+          expect { instance.get_manifest("govuk/publishing-api", "main") }.to raise_error(/Error \(401\) while fetching manifest/)
         end
       end
 
@@ -95,7 +95,7 @@ RSpec.describe DockerTagPusher do
         it "raises an error" do
           stub_request(
             :get,
-            "https://registry-1.docker.io/v2/govuk/publishing-api/manifests/master",
+            "https://registry-1.docker.io/v2/govuk/publishing-api/manifests/main",
           ).with(headers: {
             "Authorization" => "Bearer bazqux",
             "Accept" => "application/vnd.docker.distribution.manifest.v2+json",
@@ -103,7 +103,7 @@ RSpec.describe DockerTagPusher do
             "Content-Type" => "application/vnd.docker.distribution.manifest.vWrong",
           })
 
-          expect { instance.get_manifest("govuk/publishing-api", "master") }.to raise_error(/Remote image not in correct format/)
+          expect { instance.get_manifest("govuk/publishing-api", "main") }.to raise_error(/Remote image not in correct format/)
         end
       end
     end


### PR DESCRIPTION
All GOV.UK apps now use `main` as their default branch name.

Trello card: https://trello.com/c/Ms8fjnrD/2857-3-audit-and-rename-default-branches-to-main