### PR TITLE
Replace deprecated bundle install with our own task

### DIFF
--- a/jenkins.sh
+++ b/jenkins.sh
@@ -1,6 +1,8 @@
 #!/bin/bash -x
 
-bundle install --path "${HOME}/bundles/${JOB_NAME}" --deployment
+bundle config set --local path "${HOME}/bundles/${JOB_NAME}"
+bundle config set --local deployment "true"
+bundle install
 
 cd "$WORKSPACE"
 

--- a/recipes/defaults.rb
+++ b/recipes/defaults.rb
@@ -8,7 +8,6 @@ set :deploy_to,           "/data/apps/#{application}"
 set :deploy_via,          :rsync_with_remote_cache
 set :organisation,        ENV["ORGANISATION"]
 set :keep_releases,       2 # XXX: The value must be less than or equal to 2, as we only keep dependencies for 2 releases. See `cleanup_old_dependencies`.
-set :rake,                "govuk_setenv #{application} #{fetch(:rake, 'bundle exec rake')}"
 set :repo_name,           fetch(:repo_name, application).to_s # XXX: this must appear before the `require 'defaults' in recipe names
 set :repository,          "#{ENV.fetch('GIT_ORIGIN_PREFIX', 'git@github.com:alphagov')}/#{repo_name}"
 
@@ -111,24 +110,6 @@ end
 after "deploy:finalize_update", "deploy:upload_config"
 after "deploy:restart", "deploy:cleanup"
 after "deploy:update_code", "deploy:write_revision_file"
-
-namespace :deploy do
-  namespace :email do
-    task :register_subscriptions, :only => { :primary => true } do
-      rails_env = fetch(:rails_env, "production")
-      rake = fetch(:rake)
-      run "cd #{current_release}; #{rake} RAILS_ENV=#{rails_env} email_subscriptions:register_subscriptions", :once => true
-    end
-  end
-
-  namespace :"search-api" do
-    task :index, :only => { :primary => true } do
-      rails_env = fetch(:rails_env, "production")
-      rake = fetch(:rake)
-      run "cd #{current_release}; #{rake} RAILS_ENV=#{rails_env} rummager:index", :once => true
-    end
-  end
-end
 
 namespace :deploy do
   desc "Restart the procfile worker"

--- a/recipes/ruby.rb
+++ b/recipes/ruby.rb
@@ -8,7 +8,7 @@ set(:source_db_config_file, "secrets/to_upload/database.yml") unless fetch(:sour
 set(:db_config_file, "config/database.yml") unless fetch(:db_config_file, false)
 set(:rack_env,  :production)
 set(:rails_env, :production)
-set(:rake, "govuk_setenv #{fetch(:application)} #{fetch(:rake, 'bundle exec rake')}")
+set(:rake, "govuk_setenv #{fetch(:application)} bundle exec rake")
 
 namespace :deploy do
   task :start do; end


### PR DESCRIPTION
This removes the deprecated way we ran bundle install (via "bundler/capistrano" and with flags on the bundle install command) with a new task to run `bundle install` the modern way with config commands set.

This has been done to allow us to deploy apps that use Ruby 3.1 which defaults to a version of Bundler that struggles with the deprecated flags (example failed build: https://deploy.integration.publishing.service.gov.uk/job/Deploy_App/53133/)

I've tried this build out with a Ruby 2.7.6 app, Travel Advice Publisher ([build](https://deploy.integration.publishing.service.gov.uk/job/Deploy_App/53273/)) and a Ruby 3.1.2 app, Publishing API ([build](https://deploy.integration.publishing.service.gov.uk/job/Deploy_App/53272/) - don't worry that it's flagged as unstable it's because I built from a commit)