### PR TITLE
Remove "-aws" suffix for environment names in Release

### DIFF
--- a/recipes/notify.rb
+++ b/recipes/notify.rb
@@ -32,11 +32,7 @@ namespace :deploy do
             conn = Net::HTTP.new(url.host, url.port)
             conn.use_ssl = true
 
-            deployed_to_environment = if ENV["USE_S3"] == "true" && ENV["ORGANISATION"] != "integration"
-                                        "#{ENV['ORGANISATION']}-aws"
-                                      else
-                                        ENV["ORGANISATION"]
-                                      end
+            deployed_to_environment = ENV["ORGANISATION"]
 
             deployed_sha = if ENV["USE_S3"] == "false"
                              run_locally("cd #{strategy.local_cache_path} && git rev-list -n 1 #{current_revision}")


### PR DESCRIPTION
This was originally added when doing a migration of application from Carrenza to AWS. However all applications deployed now run in AWS and we don't need this suffix anymore.