### PR TITLE
Turn on default migrations, remove seed_db mongo task

### DIFF
--- a/imminence/config/deploy.rb
+++ b/imminence/config/deploy.rb
@@ -2,7 +2,7 @@ set :application, "imminence"
 set :capfile_dir, File.expand_path("../", File.dirname(__FILE__))
 set :server_class, "backend"
 
-set :run_migrations_by_default, false
+set :run_migrations_by_default, true
 
 load "defaults"
 load "ruby"
@@ -16,5 +16,4 @@ set :copy_exclude, [
   "public/templates",
 ]
 
-after "deploy:symlink", "deploy:seed_db"
 after "deploy:restart", "deploy:restart_procfile_worker"


### PR DESCRIPTION
Relies on https://github.com/alphagov/imminence/pull/766 and related infrastructure PRs.

Once Imminence is moved to RDS, this switches off deploy mongo tasks and re-enables automatic migration.