### PR TITLE
Turn on default migrations

### DIFF
--- a/authenticating-proxy/config/deploy.rb
+++ b/authenticating-proxy/config/deploy.rb
@@ -4,6 +4,8 @@ set :server_class, %w[
   draft_cache
 ]
 
+set :run_migrations_by_default, true
+
 load "defaults"
 load "ruby"
 


### PR DESCRIPTION
Relies on https://github.com/alphagov/authenticating-proxy/pull/350 and related infrastructure PRs.

Once Authenticating Proxy is moved to RDS, this re-enables automatic migration.