### PR TITLE
Add webrick as a dependency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -18,6 +18,7 @@ gem "aws-sdk-s3"
 gem "http", "~> 3.0"
 gem "rake"
 gem "rubocop-govuk"
+gem "webrick"
 gem "whenever", "0.7.3"
 
 gem "rspec"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -139,6 +139,7 @@ GEM
       unf_ext
     unf_ext (0.0.7.6)
     unicode-display_width (2.4.2)
+    webrick (1.8.1)
     whenever (0.7.3)
       activesupport (>= 2.3.4)
       chronic (~> 0.6.3)
@@ -156,6 +157,7 @@ DEPENDENCIES
   rake
   rspec
   rubocop-govuk
+  webrick
   whenever (= 0.7.3)
 
 BUNDLED WITH


### PR DESCRIPTION
Webrick was removed from the standard library as of Ruby 3.

The Licensify deploy (at least) requires it to run.

[Deploy without webrick 👎](https://deploy.integration.publishing.service.gov.uk/job/Deploy_App/61699/)

[Deploy with webrick 👍](https://deploy.integration.publishing.service.gov.uk/job/Deploy_App/61700/)